### PR TITLE
Add save data settings, UI manager, and obstacle systems

### DIFF
--- a/Assets/Scripts/Core/GameBootstrapper.cs
+++ b/Assets/Scripts/Core/GameBootstrapper.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using AngryDogs.Input;
+using AngryDogs.Systems;
+using AngryDogs.SaveSystem;
+
+namespace AngryDogs.Core
+{
+    /// <summary>
+    /// Configurable bootstrapper. Attach to a persistent prefab in the first scene.
+    /// Responsible for instantiating core services and keeping them alive across scenes.
+    /// </summary>
+    public sealed class GameBootstrapper : MonoBehaviour
+    {
+        [Header("Service Prefabs")]
+        [SerializeField] private InputManager inputManagerPrefab;
+        [SerializeField] private ObjectPooler objectPoolerPrefab;
+
+        [Header("Optional Services")]
+        [SerializeField] private SaveManager saveManagerPrefab;
+
+        private void Awake()
+        {
+            DontDestroyOnLoad(gameObject);
+            RegisterService(inputManagerPrefab);
+            RegisterService(objectPoolerPrefab);
+
+            if (saveManagerPrefab != null)
+            {
+                RegisterService(saveManagerPrefab);
+            }
+        }
+
+        private static void RegisterService<T>(T prefab) where T : Component
+        {
+            if (prefab == null)
+            {
+                Debug.LogWarning($"GameBootstrapper is missing a reference to {typeof(T).Name}.");
+                return;
+            }
+
+            if (FindObjectOfType<T>() != null)
+            {
+                // Already present in the scene (e.g., manual placement for debugging)
+                return;
+            }
+
+            var instance = Instantiate(prefab);
+            DontDestroyOnLoad(instance);
+        }
+    }
+}

--- a/Assets/Scripts/Core/GameEvents.cs
+++ b/Assets/Scripts/Core/GameEvents.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace AngryDogs.Core
+{
+    /// <summary>
+    /// Central hub for gameplay events. Keeps MonoBehaviours loosely coupled.
+    /// </summary>
+    public static class GameEvents
+    {
+        public static event Action<int> ScoreChanged;
+        public static event Action<float> RileyHealthChanged;
+        public static event Action<float> NibbleHealthChanged;
+        public static event Action<int> HoundPackCountChanged;
+        public static event Action GamePaused;
+        public static event Action GameResumed;
+        public static event Action GameOver;
+
+        public static void RaiseScoreChanged(int score) => ScoreChanged?.Invoke(score);
+        public static void RaiseRileyHealthChanged(float value) => RileyHealthChanged?.Invoke(value);
+        public static void RaiseNibbleHealthChanged(float value) => NibbleHealthChanged?.Invoke(value);
+        public static void RaiseHoundPackCountChanged(int count) => HoundPackCountChanged?.Invoke(count);
+        public static void RaiseGamePaused() => GamePaused?.Invoke();
+        public static void RaiseGameResumed() => GameResumed?.Invoke();
+        public static void RaiseGameOver() => GameOver?.Invoke();
+    }
+}

--- a/Assets/Scripts/Core/GameStateMachine.cs
+++ b/Assets/Scripts/Core/GameStateMachine.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+
+namespace AngryDogs.Core
+{
+    public enum GameState
+    {
+        Boot,
+        MainMenu,
+        Gameplay,
+        Paused,
+        Shop,
+        GameOver
+    }
+
+    /// <summary>
+    /// Lightweight finite state machine for top-level game flow.
+    /// </summary>
+    public sealed class GameStateMachine
+    {
+        private readonly Dictionary<GameState, Action> _enterHandlers = new();
+        private readonly Dictionary<GameState, Action> _exitHandlers = new();
+
+        public GameState CurrentState { get; private set; } = GameState.Boot;
+
+        public event Action<GameState> StateChanged;
+
+        public void Register(GameState state, Action onEnter, Action onExit)
+        {
+            _enterHandlers[state] = onEnter;
+            _exitHandlers[state] = onExit;
+        }
+
+        public void ChangeState(GameState nextState)
+        {
+            if (nextState == CurrentState)
+            {
+                return;
+            }
+
+            if (_exitHandlers.TryGetValue(CurrentState, out var exit))
+            {
+                exit?.Invoke();
+            }
+
+            CurrentState = nextState;
+
+            if (_enterHandlers.TryGetValue(CurrentState, out var enter))
+            {
+                enter?.Invoke();
+            }
+
+            StateChanged?.Invoke(CurrentState);
+        }
+
+        public void PauseGameplay()
+        {
+            ChangeState(GameState.Paused);
+        }
+
+        public void ResumeGameplay()
+        {
+            ChangeState(GameState.Gameplay);
+        }
+    }
+}

--- a/Assets/Scripts/Data/PlayerProgressData.cs
+++ b/Assets/Scripts/Data/PlayerProgressData.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AngryDogs.Data
+{
+    /// <summary>
+    /// Serializable data container for player persistence.
+    /// </summary>
+    [Serializable]
+    public sealed class PlayerProgressData
+    {
+        [SerializeField] private int version;
+        [SerializeField] private int highScore;
+        [SerializeField] private int currency;
+        [SerializeField] private List<string> unlockedUpgrades = new();
+
+        public int Version
+        {
+            get => version;
+            set => version = value;
+        }
+
+        public int HighScore
+        {
+            get => highScore;
+            set => highScore = Mathf.Max(highScore, value);
+        }
+
+        public int Currency
+        {
+            get => currency;
+            set => currency = Mathf.Max(0, value);
+        }
+
+        public IReadOnlyList<string> UnlockedUpgrades
+        {
+            get => unlockedUpgrades;
+            set
+            {
+                unlockedUpgrades = value != null ? new List<string>(value) : new List<string>();
+            }
+        }
+
+        public static PlayerProgressData CreateDefault()
+        {
+            return new PlayerProgressData
+            {
+                version = 1,
+                highScore = 0,
+                currency = 0,
+                unlockedUpgrades = new List<string>()
+            };
+        }
+
+        public bool HasUpgrade(string upgradeId)
+        {
+            if (string.IsNullOrEmpty(upgradeId))
+            {
+                return false;
+            }
+
+            return unlockedUpgrades != null && unlockedUpgrades.Contains(upgradeId);
+        }
+
+        public bool UnlockUpgrade(string upgradeId)
+        {
+            if (string.IsNullOrEmpty(upgradeId))
+            {
+                return false;
+            }
+
+            unlockedUpgrades ??= new List<string>();
+            if (unlockedUpgrades.Contains(upgradeId))
+            {
+                return false;
+            }
+
+            unlockedUpgrades.Add(upgradeId);
+            return true;
+        }
+
+        public bool RemoveUpgrade(string upgradeId)
+        {
+            return unlockedUpgrades != null && unlockedUpgrades.Remove(upgradeId);
+        }
+    }
+}

--- a/Assets/Scripts/Data/PlayerSaveData.cs
+++ b/Assets/Scripts/Data/PlayerSaveData.cs
@@ -1,0 +1,35 @@
+using System;
+
+namespace AngryDogs.Data
+{
+    /// <summary>
+    /// Wrapper object combining progress and settings for persistence.
+    /// </summary>
+    [Serializable]
+    public sealed class PlayerSaveData
+    {
+        public PlayerProgressData progress = PlayerProgressData.CreateDefault();
+        public PlayerSettingsData settings = PlayerSettingsData.CreateDefault();
+
+        public PlayerProgressData Progress
+        {
+            get => progress ??= PlayerProgressData.CreateDefault();
+            set => progress = value ?? PlayerProgressData.CreateDefault();
+        }
+
+        public PlayerSettingsData Settings
+        {
+            get => settings ??= PlayerSettingsData.CreateDefault();
+            set => settings = value ?? PlayerSettingsData.CreateDefault();
+        }
+
+        public static PlayerSaveData CreateDefault()
+        {
+            return new PlayerSaveData
+            {
+                progress = PlayerProgressData.CreateDefault(),
+                settings = PlayerSettingsData.CreateDefault()
+            };
+        }
+    }
+}

--- a/Assets/Scripts/Data/PlayerSettingsData.cs
+++ b/Assets/Scripts/Data/PlayerSettingsData.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AngryDogs.Data
+{
+    /// <summary>
+    /// Stores player configurable options such as key bindings and audio levels.
+    /// Designed to be lightweight for JSON serialization.
+    /// </summary>
+    [Serializable]
+    public sealed class PlayerSettingsData
+    {
+        [Serializable]
+        public struct KeyBinding
+        {
+            public string actionId;
+            public KeyCode key;
+        }
+
+        [SerializeField, Range(0f, 1f)] private float musicVolume = 0.75f;
+        [SerializeField, Range(0f, 1f)] private float sfxVolume = 0.85f;
+        [SerializeField] private bool hapticsEnabled = true;
+        [SerializeField] private bool leftHandedUi;
+        [SerializeField] private List<KeyBinding> keyBindings = new();
+
+        private Dictionary<string, KeyCode> _bindingLookup;
+
+        public float MusicVolume
+        {
+            get => musicVolume;
+            set => musicVolume = Mathf.Clamp01(value);
+        }
+
+        public float SfxVolume
+        {
+            get => sfxVolume;
+            set => sfxVolume = Mathf.Clamp01(value);
+        }
+
+        public bool HapticsEnabled
+        {
+            get => hapticsEnabled;
+            set => hapticsEnabled = value;
+        }
+
+        public bool LeftHandedUi
+        {
+            get => leftHandedUi;
+            set => leftHandedUi = value;
+        }
+
+        public IReadOnlyList<KeyBinding> Bindings => keyBindings;
+
+        public static PlayerSettingsData CreateDefault()
+        {
+            return new PlayerSettingsData
+            {
+                musicVolume = 0.75f,
+                sfxVolume = 0.85f,
+                hapticsEnabled = true,
+                leftHandedUi = false,
+                keyBindings = new List<KeyBinding>()
+            };
+        }
+
+        public void SetBinding(string actionId, KeyCode key)
+        {
+            if (string.IsNullOrEmpty(actionId))
+            {
+                return;
+            }
+
+            EnsureLookup();
+            _bindingLookup[actionId] = key;
+
+            var found = false;
+            for (var i = 0; i < keyBindings.Count; i++)
+            {
+                if (keyBindings[i].actionId == actionId)
+                {
+                    keyBindings[i] = new KeyBinding { actionId = actionId, key = key };
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+            {
+                keyBindings.Add(new KeyBinding { actionId = actionId, key = key });
+            }
+        }
+
+        public KeyCode GetBinding(string actionId, KeyCode fallback)
+        {
+            if (string.IsNullOrEmpty(actionId))
+            {
+                return fallback;
+            }
+
+            EnsureLookup();
+            return _bindingLookup.TryGetValue(actionId, out var key) ? key : fallback;
+        }
+
+        private void EnsureLookup()
+        {
+            _bindingLookup ??= new Dictionary<string, KeyCode>(StringComparer.Ordinal);
+            if (_bindingLookup.Count == keyBindings.Count)
+            {
+                return;
+            }
+
+            _bindingLookup.Clear();
+            foreach (var binding in keyBindings)
+            {
+                if (!string.IsNullOrEmpty(binding.actionId) && !_bindingLookup.ContainsKey(binding.actionId))
+                {
+                    _bindingLookup.Add(binding.actionId, binding.key);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Data/UpgradeDefinition.cs
+++ b/Assets/Scripts/Data/UpgradeDefinition.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+
+namespace AngryDogs.Data
+{
+    /// <summary>
+    /// ScriptableObject describing an upgrade purchasable in the shop.
+    /// </summary>
+    [CreateAssetMenu(menuName = "AngryDogs/Upgrade Definition", fileName = "UpgradeDefinition")]
+    public sealed class UpgradeDefinition : ScriptableObject
+    {
+        [SerializeField] private string upgradeId;
+        [SerializeField] private string displayName;
+        [SerializeField, TextArea] private string description;
+        [SerializeField] private int cost;
+        [SerializeField] private Sprite icon;
+
+        public string UpgradeId => upgradeId;
+        public string DisplayName => displayName;
+        public string Description => description;
+        public int Cost => cost;
+        public Sprite Icon => icon;
+    }
+}

--- a/Assets/Scripts/Enemies/HoundAIController.cs
+++ b/Assets/Scripts/Enemies/HoundAIController.cs
@@ -1,0 +1,284 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.AI;
+using AngryDogs.Core;
+using AngryDogs.Systems;
+
+namespace AngryDogs.Enemies
+{
+    /// <summary>
+    /// Optimized hound AI controller with lightweight state machine.
+    /// Supports fear debuff and pooled activation.
+    /// </summary>
+    [RequireComponent(typeof(NavMeshAgent))]
+    public sealed class HoundAIController : MonoBehaviour
+    {
+        private enum HoundState
+        {
+            Chasing,
+            Attacking,
+            Feared
+        }
+
+        [Header("Stats")]
+        [SerializeField] private float attackRange = 2f;
+        [SerializeField] private float attackInterval = 1.5f;
+        [SerializeField] private float damage = 10f;
+        [SerializeField, Tooltip("Seconds between NavMesh repaths. Higher values save CPU at the cost of responsiveness.")]
+        private float chaseRepathInterval = 0.2f;
+        [SerializeField, Tooltip("How far Riley must move before a new path is requested.")]
+        private float repathMovementThreshold = 0.75f;
+
+        [Header("Targets")]
+        [SerializeField] private Transform riley;
+        [SerializeField] private HealthComponent rileyHealth;
+        [SerializeField] private HealthComponent nibbleHealth;
+
+        [Header("Feedback")]
+        [SerializeField] private Animator animator;
+        [SerializeField] private ParticleSystem fearVfx;
+
+        private static int _activeCount;
+
+        private NavMeshAgent _agent;
+        private HoundState _state;
+        private float _lastAttackTime;
+        private Coroutine _fearRoutine;
+        private float _nextRepathTime;
+        private Vector3 _lastKnownRileyPosition;
+        private float _attackRangeSqr;
+        private float _repathMovementThresholdSqr;
+        private int _isRunningHash;
+        private int _biteHash;
+        private int _updateOffset;
+        private float _distanceCheckTimer;
+        private const float DistanceCheckInterval = 0.1f;
+
+        private void Awake()
+        {
+            _agent = GetComponent<NavMeshAgent>();
+            _attackRangeSqr = attackRange * attackRange;
+            _repathMovementThresholdSqr = repathMovementThreshold * repathMovementThreshold;
+            _isRunningHash = Animator.StringToHash("IsRunning");
+            _biteHash = Animator.StringToHash("Bite");
+
+            // Mobile-friendly agent defaults: turn off expensive rotation update if animator handles it.
+            _agent.updateRotation = false;
+            _agent.autoBraking = false;
+            _distanceCheckTimer = DistanceCheckInterval;
+        }
+
+        private void OnEnable()
+        {
+            _activeCount++;
+            GameEvents.RaiseHoundPackCountChanged(_activeCount);
+            SetState(HoundState.Chasing);
+            _nextRepathTime = Time.time;
+            CacheRileyPosition();
+            _updateOffset = _activeCount % 3;
+            _distanceCheckTimer = 0f;
+        }
+
+        private void OnDisable()
+        {
+            _activeCount = Mathf.Max(0, _activeCount - 1);
+            GameEvents.RaiseHoundPackCountChanged(_activeCount);
+
+            if (_fearRoutine != null)
+            {
+                StopCoroutine(_fearRoutine);
+                _fearRoutine = null;
+            }
+
+            // Reset lightweight state to play nice with pooling.
+            _lastAttackTime = 0f;
+            _nextRepathTime = 0f;
+            if (animator != null)
+            {
+                animator.Rebind();
+                animator.Update(0f);
+            }
+        }
+
+        private void Update()
+        {
+            // Stagger chasing logic across frames so 20+ hounds don't all hammer the CPU at once.
+            if (_state == HoundState.Chasing)
+            {
+                if ((Time.frameCount + _updateOffset) % 3 == 0)
+                {
+                    UpdateChasing();
+                }
+            }
+            else if (_state == HoundState.Attacking)
+            {
+                UpdateAttacking();
+            }
+        }
+
+        private void LateUpdate()
+        {
+            if (_state == HoundState.Feared)
+            {
+                return; // Fear routine manually steers movement.
+            }
+
+            var velocity = _agent.velocity;
+            velocity.y = 0f;
+            if (velocity.sqrMagnitude > 0.001f)
+            {
+                var targetRotation = Quaternion.LookRotation(velocity.normalized, Vector3.up);
+                transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.deltaTime * 10f);
+            }
+        }
+
+        private void UpdateChasing()
+        {
+            if (riley == null)
+            {
+                return;
+            }
+
+            if (ShouldRequestNewPath())
+            {
+                _agent.SetDestination(riley.position);
+                CacheRileyPosition();
+                _nextRepathTime = Time.time + chaseRepathInterval;
+            }
+
+            _distanceCheckTimer -= Time.deltaTime;
+            if (_distanceCheckTimer <= 0f)
+            {
+                _distanceCheckTimer = DistanceCheckInterval;
+            }
+            else
+            {
+                return;
+            }
+
+            if (Vector3.SqrMagnitude(riley.position - transform.position) <= _attackRangeSqr)
+            {
+                SetState(HoundState.Attacking);
+            }
+        }
+
+        private void UpdateAttacking()
+        {
+            if (riley == null)
+            {
+                SetState(HoundState.Chasing);
+                return;
+            }
+
+            if (Vector3.SqrMagnitude(riley.position - transform.position) > _attackRangeSqr * 1.2f)
+            {
+                SetState(HoundState.Chasing);
+                return;
+            }
+
+            if (Time.time - _lastAttackTime < attackInterval)
+            {
+                return;
+            }
+
+            _lastAttackTime = Time.time;
+            if (rileyHealth != null)
+            {
+                rileyHealth.ApplyDamage(damage);
+            }
+
+            if (nibbleHealth != null)
+            {
+                nibbleHealth.ApplyDamage(damage * 0.5f);
+            }
+
+            animator?.SetTrigger(_biteHash);
+        }
+
+        public void ApplyFear(float duration)
+        {
+            if (_fearRoutine != null)
+            {
+                StopCoroutine(_fearRoutine);
+            }
+
+            _fearRoutine = StartCoroutine(FearRoutine(duration));
+        }
+
+        private IEnumerator FearRoutine(float duration)
+        {
+            SetState(HoundState.Feared);
+            fearVfx?.Play();
+            var elapsed = 0f;
+            while (elapsed < duration)
+            {
+                elapsed += Time.deltaTime;
+                _agent.Move(-transform.forward * _agent.speed * 0.5f * Time.deltaTime);
+                yield return null;
+            }
+
+            fearVfx?.Stop(true, ParticleSystemStopBehavior.StopEmitting);
+            SetState(HoundState.Chasing);
+        }
+
+        private void SetState(HoundState newState)
+        {
+            _state = newState;
+            switch (_state)
+            {
+                case HoundState.Chasing:
+                    _agent.isStopped = false;
+                    if (animator != null)
+                    {
+                        animator.SetBool(_isRunningHash, true);
+                    }
+                    break;
+                case HoundState.Attacking:
+                    _agent.isStopped = true;
+                    if (animator != null)
+                    {
+                        animator.SetBool(_isRunningHash, false);
+                    }
+                    break;
+                case HoundState.Feared:
+                    _agent.isStopped = false;
+                    if (animator != null)
+                    {
+                        animator.SetBool(_isRunningHash, false);
+                    }
+                    break;
+            }
+        }
+
+        private bool ShouldRequestNewPath()
+        {
+            if (Time.time < _nextRepathTime)
+            {
+                return false;
+            }
+
+            if (Vector3.SqrMagnitude(riley.position - _lastKnownRileyPosition) < _repathMovementThresholdSqr)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private void CacheRileyPosition()
+        {
+            _lastKnownRileyPosition = riley != null ? riley.position : Vector3.zero;
+        }
+
+        /// <summary>
+        /// Allows pooled instances to get refreshed targets without extra FindObjectOfType calls.
+        /// </summary>
+        public void ConfigureTargets(Transform rileyTransform, HealthComponent rileyHp, HealthComponent nibbleHp)
+        {
+            riley = rileyTransform;
+            rileyHealth = rileyHp;
+            nibbleHealth = nibbleHp;
+            CacheRileyPosition();
+        }
+    }
+}

--- a/Assets/Scripts/Input/InputManager.cs
+++ b/Assets/Scripts/Input/InputManager.cs
@@ -1,0 +1,378 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using AngryDogs.SaveSystem;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace AngryDogs.Input
+{
+    /// <summary>
+    /// Aggregates touch, mouse, and keyboard/controller input with configurable bindings.
+    /// Emits smoothed movement/aim events consumed by gameplay coordinators.
+    /// </summary>
+    [DefaultExecutionOrder(-50)]
+    public sealed class InputManager : MonoBehaviour
+    {
+        private const string MoveLeft = "MoveLeft";
+        private const string MoveRight = "MoveRight";
+        private const string MoveUp = "MoveUp";
+        private const string MoveDown = "MoveDown";
+        private const string FireAction = "Fire";
+        private const string AbilityAction = "Ability";
+
+        [Serializable]
+        private struct DefaultBinding
+        {
+            public string actionId;
+            public KeyCode key;
+        }
+
+        [Header("Bindings")]
+        [SerializeField] private DefaultBinding[] defaultBindings =
+        {
+            new DefaultBinding { actionId = MoveLeft, key = KeyCode.A },
+            new DefaultBinding { actionId = MoveRight, key = KeyCode.D },
+            new DefaultBinding { actionId = MoveUp, key = KeyCode.W },
+            new DefaultBinding { actionId = MoveDown, key = KeyCode.S },
+            new DefaultBinding { actionId = FireAction, key = KeyCode.Mouse0 },
+            new DefaultBinding { actionId = AbilityAction, key = KeyCode.Space }
+        };
+
+        [Header("Smoothing")]
+        [SerializeField, Tooltip("Responsiveness of aim smoothing (seconds to reach target).")]
+        private float aimSmoothTime = 0.08f;
+        [SerializeField, Tooltip("Responsiveness of lateral dodge smoothing.")]
+        private float moveSmoothTime = 0.05f;
+        [SerializeField, Tooltip("Touch swipe pixels per second required for max dodge speed.")]
+        private float swipeSensitivity = 600f;
+
+        [Header("Systems")]
+        [SerializeField] private SaveManager saveManager;
+
+        public event Action<Vector2> Move;
+        public event Action<Vector2> Aim;
+        public event Action FireStarted;
+        public event Action FireCanceled;
+        public event Action Ability;
+
+        private readonly Dictionary<string, KeyCode> _bindings = new();
+        private Vector2 _smoothedMove;
+        private Vector2 _moveVelocity;
+        private Vector2 _smoothedAim;
+        private Vector2 _aimVelocity;
+        private bool _isFireHeld;
+
+#if ENABLE_INPUT_SYSTEM
+        [Header("Input System (Optional)")]
+        [SerializeField] private InputActionAsset inputActions;
+        [SerializeField] private string actionMap = "Gameplay";
+        [SerializeField] private string moveActionName = "Move";
+        [SerializeField] private string aimActionName = "Aim";
+        [SerializeField] private string fireActionName = "Fire";
+        [SerializeField] private string abilityActionName = "Ability";
+
+        private InputAction _moveAction;
+        private InputAction _aimAction;
+        private InputAction _fireAction;
+        private InputAction _abilityAction;
+#endif
+
+        private void Awake()
+        {
+            BootstrapBindings();
+        }
+
+        private void OnEnable()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (inputActions != null)
+            {
+                var map = inputActions.FindActionMap(actionMap, throwIfNotFound: false);
+                if (map != null)
+                {
+                    _moveAction = map.FindAction(moveActionName, throwIfNotFound: false);
+                    _aimAction = map.FindAction(aimActionName, throwIfNotFound: false);
+                    _fireAction = map.FindAction(fireActionName, throwIfNotFound: false);
+                    _abilityAction = map.FindAction(abilityActionName, throwIfNotFound: false);
+
+                    _moveAction?.Enable();
+                    _aimAction?.Enable();
+                    _fireAction?.Enable();
+                    _abilityAction?.Enable();
+
+                    if (_fireAction != null)
+                    {
+                        _fireAction.performed += OnFirePerformed;
+                        _fireAction.canceled += OnFireCanceled;
+                    }
+
+                    if (_abilityAction != null)
+                    {
+                        _abilityAction.performed += OnAbilityPerformed;
+                    }
+                }
+            }
+#endif
+        }
+
+        private void OnDisable()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_fireAction != null)
+            {
+                _fireAction.performed -= OnFirePerformed;
+                _fireAction.canceled -= OnFireCanceled;
+            }
+
+            if (_abilityAction != null)
+            {
+                _abilityAction.performed -= OnAbilityPerformed;
+            }
+#endif
+        }
+
+        private void Update()
+        {
+            var move = ReadMove();
+            _smoothedMove = Vector2.SmoothDamp(_smoothedMove, move, ref _moveVelocity, moveSmoothTime);
+            Move?.Invoke(_smoothedMove);
+
+            var aim = ReadAim();
+            _smoothedAim = Vector2.SmoothDamp(_smoothedAim, aim, ref _aimVelocity, aimSmoothTime);
+            Aim?.Invoke(_smoothedAim);
+
+            PollFire();
+            PollAbility();
+        }
+
+        public void Rebind(string actionId, KeyCode key)
+        {
+            if (string.IsNullOrEmpty(actionId))
+            {
+                return;
+            }
+
+            _bindings[actionId] = key;
+            if (saveManager != null)
+            {
+                saveManager.StoreKeyBinding(actionId, key);
+            }
+            else
+            {
+                PlayerPrefs.SetInt(actionId, (int)key);
+                PlayerPrefs.Save();
+            }
+        }
+
+        public KeyCode GetBinding(string actionId)
+        {
+            return _bindings.TryGetValue(actionId, out var key) ? key : KeyCode.None;
+        }
+
+        private void BootstrapBindings()
+        {
+            _bindings.Clear();
+            foreach (var binding in defaultBindings)
+            {
+                if (string.IsNullOrEmpty(binding.actionId))
+                {
+                    continue;
+                }
+
+                var key = binding.key;
+                if (saveManager != null)
+                {
+                    key = saveManager.LoadKeyBinding(binding.actionId, binding.key);
+                }
+                else if (PlayerPrefs.HasKey(binding.actionId))
+                {
+                    key = (KeyCode)PlayerPrefs.GetInt(binding.actionId);
+                }
+
+                _bindings[binding.actionId] = key;
+            }
+        }
+
+        private Vector2 ReadMove()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_moveAction != null)
+            {
+                var value = _moveAction.ReadValue<Vector2>();
+                if (value.sqrMagnitude > 0.0001f)
+                {
+                    return Vector2.ClampMagnitude(value, 1f);
+                }
+            }
+#endif
+
+            if (UnityEngine.Input.touchCount > 0)
+            {
+                var touch = UnityEngine.Input.GetTouch(0);
+                if (touch.phase == TouchPhase.Moved)
+                {
+                    var normalizedX = Mathf.Clamp(touch.deltaPosition.x / swipeSensitivity, -1f, 1f);
+                    return new Vector2(normalizedX, 0f);
+                }
+            }
+
+            var horizontal = 0f;
+            if (IsBindingPressed(MoveLeft))
+            {
+                horizontal -= 1f;
+            }
+            if (IsBindingPressed(MoveRight))
+            {
+                horizontal += 1f;
+            }
+
+            var vertical = 0f;
+            if (IsBindingPressed(MoveUp))
+            {
+                vertical += 1f;
+            }
+            if (IsBindingPressed(MoveDown))
+            {
+                vertical -= 1f;
+            }
+
+            return Vector2.ClampMagnitude(new Vector2(horizontal, vertical), 1f);
+        }
+
+        private Vector2 ReadAim()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_aimAction != null)
+            {
+                var value = _aimAction.ReadValue<Vector2>();
+                if (value.sqrMagnitude > 0.0001f)
+                {
+                    return Vector2.ClampMagnitude(value, 1f);
+                }
+            }
+#endif
+
+            if (UnityEngine.Input.touchCount > 0)
+            {
+                var touch = UnityEngine.Input.GetTouch(0);
+                var viewport = new Vector2(
+                    Mathf.Clamp01(touch.position.x / Screen.width) * 2f - 1f,
+                    Mathf.Clamp01(touch.position.y / Screen.height) * 2f - 1f);
+                return Vector2.ClampMagnitude(viewport, 1f);
+            }
+
+            var pointer = (Vector2)UnityEngine.Input.mousePosition;
+            var aim = new Vector2(
+                Mathf.Clamp(pointer.x / Screen.width * 2f - 1f, -1f, 1f),
+                Mathf.Clamp(pointer.y / Screen.height * 2f - 1f, -1f, 1f));
+            return aim;
+        }
+
+        private void PollFire()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_fireAction != null)
+            {
+                return; // Events already fired via callbacks.
+            }
+#endif
+            var firePressed = IsBindingDown(FireAction) || UnityEngine.Input.GetMouseButtonDown(0);
+            var fireReleased = IsBindingUp(FireAction) || UnityEngine.Input.GetMouseButtonUp(0);
+
+            if (!_isFireHeld && firePressed)
+            {
+                _isFireHeld = true;
+                FireStarted?.Invoke();
+            }
+
+            if (_isFireHeld && fireReleased)
+            {
+                _isFireHeld = false;
+                FireCanceled?.Invoke();
+            }
+
+            // Quick tap auto-fire on touch screens.
+            if (UnityEngine.Input.touchCount == 1)
+            {
+                var touch = UnityEngine.Input.GetTouch(0);
+                if (touch.phase == TouchPhase.Ended && touch.deltaTime < 0.2f)
+                {
+                    FireStarted?.Invoke();
+                    FireCanceled?.Invoke();
+                }
+            }
+        }
+
+        private void PollAbility()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_abilityAction != null)
+            {
+                return; // Input System events handle ability triggers.
+            }
+#endif
+            if (IsBindingDown(AbilityAction))
+            {
+                Ability?.Invoke();
+            }
+        }
+
+        private bool IsBindingPressed(string actionId)
+        {
+            if (!_bindings.TryGetValue(actionId, out var key))
+            {
+                return false;
+            }
+
+            return UnityEngine.Input.GetKey(key);
+        }
+
+        private bool IsBindingDown(string actionId)
+        {
+            if (!_bindings.TryGetValue(actionId, out var key))
+            {
+                return false;
+            }
+
+            return UnityEngine.Input.GetKeyDown(key);
+        }
+
+        private bool IsBindingUp(string actionId)
+        {
+            if (!_bindings.TryGetValue(actionId, out var key))
+            {
+                return false;
+            }
+
+            return UnityEngine.Input.GetKeyUp(key);
+        }
+
+#if ENABLE_INPUT_SYSTEM
+        private void OnFirePerformed(InputAction.CallbackContext context)
+        {
+            if (!_isFireHeld)
+            {
+                _isFireHeld = true;
+                FireStarted?.Invoke();
+            }
+        }
+
+        private void OnFireCanceled(InputAction.CallbackContext context)
+        {
+            if (_isFireHeld)
+            {
+                _isFireHeld = false;
+                FireCanceled?.Invoke();
+            }
+        }
+
+        private void OnAbilityPerformed(InputAction.CallbackContext context)
+        {
+            Ability?.Invoke();
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Input/PlayerInputHandler.cs
+++ b/Assets/Scripts/Input/PlayerInputHandler.cs
@@ -1,0 +1,175 @@
+using System;
+using UnityEngine;
+
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
+
+namespace AngryDogs.Input
+{
+    /// <summary>
+    /// Abstracts player input for keyboard/mouse, controller, and touch.
+    /// Provides smoothed aiming/dodge commands via events consumed by gameplay components.
+    /// </summary>
+    [System.Obsolete("Use InputManager for new systems.")]
+    public sealed class PlayerInputHandler : MonoBehaviour
+    {
+        public event Action<Vector2> MoveInput;
+        public event Action<Vector2> AimInput;
+        public event Action FirePressed;
+        public event Action FireReleased;
+        public event Action AbilityPressed;
+
+        [Header("Settings")]
+        [SerializeField, Tooltip("Blend factor per second for smoothing aim input.")]
+        private float aimSmoothing = 12f;
+        [SerializeField, Tooltip("Seconds that qualify as a quick tap for auto-fire on touch.")]
+        private float tapThreshold = 0.2f;
+
+        private Vector2 _currentAim;
+
+#if ENABLE_INPUT_SYSTEM
+        [SerializeField] private InputActionAsset actions;
+        private InputAction _moveAction;
+        private InputAction _aimAction;
+        private InputAction _fireAction;
+        private InputAction _abilityAction;
+#endif
+
+        private void OnEnable()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (actions != null)
+            {
+                _moveAction = actions.FindAction("Gameplay/Move");
+                _aimAction = actions.FindAction("Gameplay/Aim");
+                _fireAction = actions.FindAction("Gameplay/Fire");
+                _abilityAction = actions.FindAction("Gameplay/Ability");
+
+                _moveAction?.Enable();
+                _aimAction?.Enable();
+                _fireAction?.Enable();
+                _abilityAction?.Enable();
+
+                if (_fireAction != null)
+                {
+                    _fireAction.performed += OnFirePerformed;
+                    _fireAction.canceled += OnFireCanceled;
+                }
+
+                if (_abilityAction != null)
+                {
+                    _abilityAction.performed += OnAbilityPerformed;
+                }
+            }
+#endif
+        }
+
+        private void OnDisable()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_fireAction != null)
+            {
+                _fireAction.performed -= OnFirePerformed;
+                _fireAction.canceled -= OnFireCanceled;
+            }
+
+            if (_abilityAction != null)
+            {
+                _abilityAction.performed -= OnAbilityPerformed;
+            }
+#endif
+        }
+
+        private void Update()
+        {
+            var move = ReadMove();
+            MoveInput?.Invoke(move);
+
+            var rawAim = ReadAim();
+            _currentAim = Vector2.Lerp(_currentAim, rawAim, 1f - Mathf.Exp(-aimSmoothing * Time.deltaTime));
+            AimInput?.Invoke(_currentAim);
+
+#if !ENABLE_INPUT_SYSTEM
+            // Legacy polling for fire/ability
+            if (UnityEngine.Input.GetButtonDown("Fire1"))
+            {
+                FirePressed?.Invoke();
+            }
+            if (UnityEngine.Input.GetButtonUp("Fire1"))
+            {
+                FireReleased?.Invoke();
+            }
+            if (UnityEngine.Input.GetButtonDown("Fire2"))
+            {
+                AbilityPressed?.Invoke();
+            }
+#endif
+        }
+
+        private Vector2 ReadMove()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_moveAction != null)
+            {
+                return _moveAction.ReadValue<Vector2>();
+            }
+#endif
+            // Legacy fallback: horizontal axis = dodge lanes, vertical for speed boosts.
+            return new Vector2(UnityEngine.Input.GetAxis("Horizontal"), UnityEngine.Input.GetAxis("Vertical"));
+        }
+
+        private Vector2 ReadAim()
+        {
+#if ENABLE_INPUT_SYSTEM
+            if (_aimAction != null)
+            {
+                return _aimAction.ReadValue<Vector2>();
+            }
+#endif
+            var pointer = (Vector2)UnityEngine.Input.mousePosition;
+            if (UnityEngine.Input.touchCount > 0)
+            {
+                pointer = UnityEngine.Input.GetTouch(0).position;
+            }
+
+            var viewportPoint = new Vector2(
+                pointer.x / Screen.width * 2f - 1f,
+                pointer.y / Screen.height * 2f - 1f);
+            return viewportPoint;
+        }
+
+#if ENABLE_INPUT_SYSTEM
+        private void OnFirePerformed(InputAction.CallbackContext context)
+        {
+            FirePressed?.Invoke();
+        }
+
+        private void OnFireCanceled(InputAction.CallbackContext context)
+        {
+            FireReleased?.Invoke();
+        }
+
+        private void OnAbilityPerformed(InputAction.CallbackContext context)
+        {
+            AbilityPressed?.Invoke();
+        }
+#endif
+
+        private void LateUpdate()
+        {
+            // Quick tap detection for touch screens (auto-fire).
+            if (UnityEngine.Input.touchCount == 0)
+            {
+                return;
+            }
+
+            var touch = UnityEngine.Input.GetTouch(0);
+            if (touch.phase == TouchPhase.Ended && touch.deltaTime <= tapThreshold)
+            {
+                FirePressed?.Invoke();
+                FireReleased?.Invoke();
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/ObstacleManager.cs
+++ b/Assets/Scripts/Obstacles/ObstacleManager.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using AngryDogs.Systems;
+
+namespace AngryDogs.Obstacles
+{
+    /// <summary>
+    /// Handles obstacle spawning, pooling, and goofy repurposing into traps for Riley and Nibble.
+    /// </summary>
+    public sealed class ObstacleManager : MonoBehaviour
+    {
+        [Serializable]
+        public class ObstacleDefinition
+        {
+            public string id = "SlobberCannon";
+            public GameObject obstaclePrefab;
+            public GameObject repurposedPrefab;
+            [Tooltip("Relative chance for this obstacle to spawn compared to others.")]
+            public float weight = 1f;
+            [Tooltip("Scale multiplier applied to the repurposed defence.")]
+            public Vector3 repurposedScale = Vector3.one;
+            [Tooltip("Optional SFX when the obstacle is repurposed.")]
+            public AudioClip repurposedClip;
+            [Tooltip("Optional spawn SFX because neon cannons deserve fanfare.")]
+            public AudioClip spawnClip;
+            [Tooltip("Distance from Riley after which this obstacle despawns.")]
+            public float despawnDistance = 20f;
+        }
+
+        private struct ActiveObstacle
+        {
+            public ObstacleDefinition Definition;
+            public GameObject Instance;
+            public bool Repurposed;
+        }
+
+        [Header("Player Tracking")]
+        [SerializeField] private Transform player;
+        [SerializeField] private float forwardSpawnOffset = 30f;
+        [SerializeField] private float laneWidth = 3f;
+        [SerializeField] private int laneCount = 3;
+
+        [Header("Spawning")]
+        [SerializeField] private AnimationCurve spawnIntervalCurve = AnimationCurve.Linear(0f, 3f, 240f, 1f);
+        [SerializeField, Tooltip("Hard limit for active obstacles to avoid GC spikes.")]
+        private int maxActiveObstacles = 48;
+        [SerializeField] private List<ObstacleDefinition> obstacleDefinitions = new();
+
+        [Header("Systems")]
+        [SerializeField] private ObjectPooler pooler;
+        [SerializeField] private AudioSource sfxSource;
+
+        public event Action<ObstacleDefinition, GameObject> ObstacleSpawned;
+        public event Action<ObstacleDefinition, GameObject> ObstacleRepurposed;
+
+        private readonly List<ActiveObstacle> _activeObstacles = new(64);
+        private readonly Dictionary<GameObject, int> _lookup = new();
+        private readonly WeightedObstaclePicker _picker = new();
+
+        private float _elapsed;
+        private float _spawnTimer;
+        private System.Random _random;
+        private bool _warnedAboutSaturation;
+
+        public int ActiveCount => _activeObstacles.Count;
+
+        public void SetRandomSeed(int seed)
+        {
+            _random = new System.Random(seed);
+        }
+
+        public void ConfigureObstacles(IEnumerable<ObstacleDefinition> definitions)
+        {
+            obstacleDefinitions = definitions != null
+                ? new List<ObstacleDefinition>(definitions)
+                : new List<ObstacleDefinition>();
+            _picker.Configure(obstacleDefinitions);
+            _warnedAboutSaturation = false;
+        }
+
+        private void Awake()
+        {
+            _random = new System.Random(1337);
+            _picker.Configure(obstacleDefinitions);
+
+            if (pooler == null)
+            {
+                pooler = FindObjectOfType<ObjectPooler>();
+            }
+        }
+
+        private void Update()
+        {
+            if (player == null || pooler == null || _picker.Count == 0)
+            {
+                return;
+            }
+
+            _elapsed += Time.deltaTime;
+            _spawnTimer -= Time.deltaTime;
+
+            if (_spawnTimer <= 0f && _activeObstacles.Count < maxActiveObstacles)
+            {
+                SpawnObstacle();
+                var interval = Mathf.Clamp(spawnIntervalCurve.Evaluate(_elapsed), 0.35f, 6f);
+                _spawnTimer = interval;
+            }
+            else if (!_warnedAboutSaturation && _activeObstacles.Count >= maxActiveObstacles)
+            {
+                Debug.LogWarning("ObstacleManager: Active obstacle cap reached. Consider raising maxActiveObstacles or tuning spawn curve to avoid draw call spikes.");
+                _warnedAboutSaturation = true;
+            }
+
+            CullObstacles();
+        }
+
+        public void ResetManager()
+        {
+            for (var i = _activeObstacles.Count - 1; i >= 0; i--)
+            {
+                var entry = _activeObstacles[i];
+                pooler.Return(entry.Instance);
+            }
+
+            _activeObstacles.Clear();
+            _lookup.Clear();
+            _elapsed = 0f;
+            _spawnTimer = 0f;
+            _warnedAboutSaturation = false;
+        }
+
+        public void NotifyObstacleDestroyed(GameObject obstacle, Vector3 hitPoint, Vector3 normal)
+        {
+            if (obstacle == null || !_lookup.TryGetValue(obstacle, out var index))
+            {
+                return;
+            }
+
+            var entry = _activeObstacles[index];
+            if (entry.Repurposed)
+            {
+                return; // Already turned into a slime slide.
+            }
+
+            pooler.Return(entry.Instance);
+            RemoveAt(index);
+
+            if (entry.Definition.repurposedPrefab == null)
+            {
+                return;
+            }
+
+            if (normal == Vector3.zero)
+            {
+                normal = Vector3.up;
+            }
+
+            var trap = pooler.Get(entry.Definition.repurposedPrefab, hitPoint, Quaternion.LookRotation(normal, Vector3.up));
+            if (trap == null)
+            {
+                return;
+            }
+            trap.transform.localScale = entry.Definition.repurposedScale;
+            PlayClip(entry.Definition.repurposedClip);
+
+            var repurposed = new ActiveObstacle
+            {
+                Definition = entry.Definition,
+                Instance = trap,
+                Repurposed = true
+            };
+
+            _lookup[trap] = _activeObstacles.Count;
+            _activeObstacles.Add(repurposed);
+            ObstacleRepurposed?.Invoke(entry.Definition, trap);
+        }
+
+        private void SpawnObstacle()
+        {
+            var sample = (float)_random.NextDouble();
+            var definition = _picker.Pick(sample);
+            if (definition == null)
+            {
+                return;
+            }
+
+            var laneIndex = _random.Next(Mathf.Max(1, laneCount));
+            var centered = laneIndex - (laneCount - 1) * 0.5f;
+            var offset = player.right * (centered * laneWidth);
+            var position = player.position + player.forward * forwardSpawnOffset + offset;
+
+            var obstacle = pooler.Get(definition.obstaclePrefab, position, Quaternion.identity);
+            var entry = new ActiveObstacle
+            {
+                Definition = definition,
+                Instance = obstacle,
+                Repurposed = false
+            };
+
+            _lookup[obstacle] = _activeObstacles.Count;
+            _activeObstacles.Add(entry);
+            PlayClip(definition.spawnClip);
+            ObstacleSpawned?.Invoke(definition, obstacle);
+        }
+
+        private void CullObstacles()
+        {
+            for (var i = _activeObstacles.Count - 1; i >= 0; i--)
+            {
+                var entry = _activeObstacles[i];
+                if (entry.Instance == null)
+                {
+                    RemoveAt(i);
+                    continue;
+                }
+
+                var distance = player.position.z - entry.Instance.transform.position.z;
+                var despawnThreshold = entry.Definition.despawnDistance;
+                if (entry.Repurposed)
+                {
+                    despawnThreshold *= 1.5f; // Let traps linger slightly longer.
+                }
+
+                if (distance > despawnThreshold)
+                {
+                    pooler.Return(entry.Instance);
+                    RemoveAt(i);
+                }
+            }
+        }
+
+        private void RemoveAt(int index)
+        {
+            var lastIndex = _activeObstacles.Count - 1;
+            var removed = _activeObstacles[index];
+            _lookup.Remove(removed.Instance);
+
+            if (index != lastIndex)
+            {
+                var swap = _activeObstacles[lastIndex];
+                _activeObstacles[index] = swap;
+                _lookup[swap.Instance] = index;
+            }
+
+            _activeObstacles.RemoveAt(lastIndex);
+        }
+
+        private void PlayClip(AudioClip clip)
+        {
+            if (clip == null || sfxSource == null)
+            {
+                return;
+            }
+
+            sfxSource.PlayOneShot(clip);
+        }
+    }
+}

--- a/Assets/Scripts/Obstacles/WeightedObstaclePicker.cs
+++ b/Assets/Scripts/Obstacles/WeightedObstaclePicker.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AngryDogs.Obstacles
+{
+    /// <summary>
+    /// Deterministic weighted picker that avoids per-frame allocations.
+    /// </summary>
+    public sealed class WeightedObstaclePicker
+    {
+        private readonly List<float> _cumulativeWeights = new();
+        private readonly List<ObstacleManager.ObstacleDefinition> _definitions = new();
+        private float _totalWeight;
+
+        public int Count => _definitions.Count;
+
+        public void Configure(IReadOnlyList<ObstacleManager.ObstacleDefinition> definitions)
+        {
+            _definitions.Clear();
+            _cumulativeWeights.Clear();
+            _totalWeight = 0f;
+
+            if (definitions == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < definitions.Count; i++)
+            {
+                var definition = definitions[i];
+                if (definition == null || definition.weight <= 0f || definition.obstaclePrefab == null)
+                {
+                    continue;
+                }
+
+                _totalWeight += definition.weight;
+                _definitions.Add(definition);
+                _cumulativeWeights.Add(_totalWeight);
+            }
+        }
+
+        public ObstacleManager.ObstacleDefinition Pick(float sample)
+        {
+            if (_definitions.Count == 0)
+            {
+                return null;
+            }
+
+            var clamped = Mathf.Clamp01(sample);
+            var target = clamped * _totalWeight;
+            for (var i = 0; i < _cumulativeWeights.Count; i++)
+            {
+                if (target <= _cumulativeWeights[i])
+                {
+                    return _definitions[i];
+                }
+            }
+
+            return _definitions[^1];
+        }
+    }
+}

--- a/Assets/Scripts/Player/NibbleCompanionController.cs
+++ b/Assets/Scripts/Player/NibbleCompanionController.cs
@@ -1,0 +1,73 @@
+using System.Collections;
+using UnityEngine;
+using AngryDogs.Enemies;
+using AngryDogs.Systems;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Controls Nibble's fetch loops and support abilities.
+    /// </summary>
+    public sealed class NibbleCompanionController : MonoBehaviour
+    {
+        [SerializeField] private float fetchCooldown = 6f;
+        [SerializeField] private float abilityRadius = 6f;
+        [SerializeField] private LayerMask houndMask;
+        [SerializeField] private Animator animator;
+        [SerializeField] private ParticleSystem abilityVfx;
+
+        private Coroutine _fetchRoutine;
+
+        private void OnEnable()
+        {
+            _fetchRoutine = StartCoroutine(FetchLoop());
+        }
+
+        private void OnDisable()
+        {
+            if (_fetchRoutine != null)
+            {
+                StopCoroutine(_fetchRoutine);
+                _fetchRoutine = null;
+            }
+        }
+
+        private IEnumerator FetchLoop()
+        {
+            var wait = new WaitForSeconds(fetchCooldown);
+            while (true)
+            {
+                yield return wait;
+                TriggerAbility();
+            }
+        }
+
+        public void TriggerAbility()
+        {
+            animator?.SetTrigger("Bark");
+            abilityVfx?.Play();
+
+            var hits = Physics.OverlapSphere(transform.position, abilityRadius, houndMask);
+            foreach (var hit in hits)
+            {
+                if (hit.TryGetComponent(out HoundAIController hound))
+                {
+                    hound.ApplyFear(2f);
+                }
+            }
+        }
+
+        public void OnRileyHit()
+        {
+            animator?.SetTrigger("Worried");
+        }
+
+        public void OnGameOver()
+        {
+            if (abilityVfx != null)
+            {
+                abilityVfx.Stop(true, ParticleSystemStopBehavior.StopEmitting);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Player/NibbleInteractionCoordinator.cs
+++ b/Assets/Scripts/Player/NibbleInteractionCoordinator.cs
@@ -1,0 +1,70 @@
+using UnityEngine;
+using AngryDogs.Input;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Responsible solely for coordinating Nibble's interactions and ability triggers.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class NibbleInteractionCoordinator : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField] private InputManager inputManager;
+        [SerializeField] private NibbleCompanionController nibble;
+
+        private void Reset()
+        {
+            if (nibble == null)
+            {
+                nibble = GetComponentInChildren<NibbleCompanionController>();
+            }
+
+            inputManager = FindObjectOfType<InputManager>();
+        }
+
+        private void Awake()
+        {
+            if (nibble == null)
+            {
+                nibble = GetComponentInChildren<NibbleCompanionController>();
+            }
+
+            if (inputManager == null)
+            {
+                inputManager = FindObjectOfType<InputManager>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Ability += HandleAbility;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Ability -= HandleAbility;
+            }
+        }
+
+        public void HandleRileyDamaged()
+        {
+            nibble?.OnRileyHit();
+        }
+
+        public void HandleGameOver()
+        {
+            nibble?.OnGameOver();
+        }
+
+        private void HandleAbility()
+        {
+            nibble?.TriggerAbility();
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Slim orchestration layer that wires the player's dedicated coordinators together.
+    /// Keeps high-level flow readable while each component follows the single-responsibility principle.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(PlayerMovementController))]
+    [RequireComponent(typeof(PlayerShooter))]
+    [RequireComponent(typeof(PlayerMovementCoordinator))]
+    [RequireComponent(typeof(PlayerShootingCoordinator))]
+    [RequireComponent(typeof(PlayerHealthResponder))]
+    public sealed class PlayerController : MonoBehaviour
+    {
+        [Header("Coordinators")]
+        [SerializeField] private PlayerMovementCoordinator movementCoordinator;
+        [SerializeField] private PlayerShootingCoordinator shootingCoordinator;
+        [SerializeField] private NibbleInteractionCoordinator nibbleCoordinator;
+        [SerializeField] private PlayerHealthResponder healthResponder;
+
+        private void Reset()
+        {
+            movementCoordinator = GetComponent<PlayerMovementCoordinator>();
+            shootingCoordinator = GetComponent<PlayerShootingCoordinator>();
+            healthResponder = GetComponent<PlayerHealthResponder>();
+
+            if (nibbleCoordinator == null)
+            {
+                nibbleCoordinator = GetComponentInChildren<NibbleInteractionCoordinator>();
+            }
+        }
+
+        private void Awake()
+        {
+            if (movementCoordinator == null)
+            {
+                movementCoordinator = GetComponent<PlayerMovementCoordinator>();
+            }
+
+            if (shootingCoordinator == null)
+            {
+                shootingCoordinator = GetComponent<PlayerShootingCoordinator>();
+            }
+
+            if (healthResponder == null)
+            {
+                healthResponder = GetComponent<PlayerHealthResponder>();
+            }
+
+            if (nibbleCoordinator == null)
+            {
+                nibbleCoordinator = GetComponentInChildren<NibbleInteractionCoordinator>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (healthResponder != null)
+            {
+                healthResponder.RileyDamaged += OnRileyDamaged;
+                healthResponder.NibbleDamaged += OnNibbleDamaged;
+                healthResponder.GameOver += OnGameOver;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (healthResponder != null)
+            {
+                healthResponder.RileyDamaged -= OnRileyDamaged;
+                healthResponder.NibbleDamaged -= OnNibbleDamaged;
+                healthResponder.GameOver -= OnGameOver;
+            }
+        }
+
+        private void OnRileyDamaged(float _)
+        {
+            nibbleCoordinator?.HandleRileyDamaged();
+        }
+
+        private void OnNibbleDamaged(float _)
+        {
+            shootingCoordinator?.HandleCompanionDamage();
+        }
+
+        private void OnGameOver()
+        {
+            shootingCoordinator?.HandleGameOver();
+            nibbleCoordinator?.HandleGameOver();
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerHealthResponder.cs
+++ b/Assets/Scripts/Player/PlayerHealthResponder.cs
@@ -1,0 +1,90 @@
+using System;
+using UnityEngine;
+using AngryDogs.Systems;
+using AngryDogs.Core;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Consolidates Riley and Nibble health callbacks and emits strongly typed events for other coordinators.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PlayerHealthResponder : MonoBehaviour
+    {
+        [Header("Health References")]
+        [SerializeField] private HealthComponent rileyHealth;
+        [SerializeField] private HealthComponent nibbleHealth;
+
+        [Header("Cooldowns")]
+        [SerializeField, Tooltip("Seconds before Riley can complain about the same bite again.")]
+        private float damageCooldown = 0.75f;
+
+        public event Action<float> RileyDamaged;
+        public event Action<float> NibbleDamaged;
+        public event Action GameOver;
+
+        private float _nextDamageTime;
+
+        private void Awake()
+        {
+            if (rileyHealth == null)
+            {
+                rileyHealth = GetComponentInChildren<HealthComponent>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (rileyHealth != null)
+            {
+                rileyHealth.Damaged += HandleRileyDamaged;
+                rileyHealth.Died += HandleGameOver;
+            }
+
+            if (nibbleHealth != null)
+            {
+                nibbleHealth.Damaged += HandleNibbleDamaged;
+                nibbleHealth.Died += HandleGameOver;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (rileyHealth != null)
+            {
+                rileyHealth.Damaged -= HandleRileyDamaged;
+                rileyHealth.Died -= HandleGameOver;
+            }
+
+            if (nibbleHealth != null)
+            {
+                nibbleHealth.Damaged -= HandleNibbleDamaged;
+                nibbleHealth.Died -= HandleGameOver;
+            }
+        }
+
+        private void HandleRileyDamaged(float remaining)
+        {
+            if (Time.time < _nextDamageTime)
+            {
+                return;
+            }
+
+            _nextDamageTime = Time.time + damageCooldown;
+            GameEvents.RaiseRileyHealthChanged(remaining);
+            RileyDamaged?.Invoke(remaining);
+        }
+
+        private void HandleNibbleDamaged(float remaining)
+        {
+            GameEvents.RaiseNibbleHealthChanged(remaining);
+            NibbleDamaged?.Invoke(remaining);
+        }
+
+        private void HandleGameOver()
+        {
+            GameEvents.RaiseGameOver();
+            GameOver?.Invoke();
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerMovementController.cs
+++ b/Assets/Scripts/Player/PlayerMovementController.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Handles forward sprinting and lane-based dodging for Riley.
+    /// </summary>
+    [RequireComponent(typeof(CharacterController))]
+    public sealed class PlayerMovementController : MonoBehaviour
+    {
+        [Header("Speed")]
+        [SerializeField] private float forwardSpeed = 12f;
+        [SerializeField] private float lateralSpeed = 8f;
+        [SerializeField] private float gravity = -30f;
+
+        [Header("Lane Settings")]
+        [SerializeField] private float laneWidth = 3f;
+        [SerializeField] private int laneCount = 3;
+        [SerializeField, Tooltip("Smoothing factor for lateral lerp.")]
+        private float laneLerp = 12f;
+
+        private CharacterController _controller;
+        private Vector2 _cachedInput;
+        private float _verticalVelocity;
+        private float _targetLaneOffset;
+        private float _currentLaneOffset;
+
+        private void Awake()
+        {
+            _controller = GetComponent<CharacterController>();
+        }
+
+        public void ProcessInput(Vector2 input)
+        {
+            _cachedInput = input;
+        }
+
+        private void Update()
+        {
+            MoveForward();
+            ApplyGravity();
+        }
+
+        private void MoveForward()
+        {
+            _targetLaneOffset += _cachedInput.x * laneWidth * Time.deltaTime;
+            _targetLaneOffset = Mathf.Clamp(_targetLaneOffset, -LaneHalfWidth(), LaneHalfWidth());
+            _currentLaneOffset = Mathf.Lerp(_currentLaneOffset, _targetLaneOffset, 1f - Mathf.Exp(-laneLerp * Time.deltaTime));
+
+            var targetPosition = transform.TransformPoint(new Vector3(_currentLaneOffset, 0f, 0f));
+            var lateralDirection = (targetPosition - transform.position);
+            lateralDirection.y = 0f;
+
+            var lateralVelocity = lateralDirection.normalized * lateralSpeed;
+            var forwardVelocity = transform.forward * forwardSpeed;
+
+            var displacement = (forwardVelocity + lateralVelocity) * Time.deltaTime;
+            displacement.y = _verticalVelocity * Time.deltaTime;
+            _controller.Move(displacement);
+        }
+
+        private void ApplyGravity()
+        {
+            if (_controller.isGrounded)
+            {
+                _verticalVelocity = -1f; // small negative to keep grounded
+            }
+            else
+            {
+                _verticalVelocity += gravity * Time.deltaTime;
+            }
+        }
+
+        private float LaneHalfWidth()
+        {
+            var totalWidth = (laneCount - 1) * laneWidth;
+            return totalWidth * 0.5f;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerMovementCoordinator.cs
+++ b/Assets/Scripts/Player/PlayerMovementCoordinator.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+using AngryDogs.Input;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Bridges raw player input to the movement controller. Keeps lane dodging logic isolated.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PlayerMovementCoordinator : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField] private InputManager inputManager;
+        [SerializeField] private PlayerMovementController movement;
+
+        private void Reset()
+        {
+            movement = GetComponent<PlayerMovementController>();
+            inputManager = FindObjectOfType<InputManager>();
+        }
+
+        private void Awake()
+        {
+            if (movement == null)
+            {
+                movement = GetComponent<PlayerMovementController>();
+            }
+
+            if (inputManager == null)
+            {
+                inputManager = FindObjectOfType<InputManager>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Move += HandleMove;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Move -= HandleMove;
+            }
+        }
+
+        private void HandleMove(Vector2 move)
+        {
+            movement?.ProcessInput(move);
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerShooter.cs
+++ b/Assets/Scripts/Player/PlayerShooter.cs
@@ -1,0 +1,108 @@
+using System.Collections;
+using UnityEngine;
+using AngryDogs.Systems;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Controls projectile spawning and obstacle repurposing logic.
+    /// </summary>
+    public sealed class PlayerShooter : MonoBehaviour
+    {
+        [Header("Weapon")]
+        [SerializeField] private float fireRate = 8f;
+        [SerializeField] private float boostedFireRate = 12f;
+        [SerializeField] private float boostedDuration = 3f;
+        [SerializeField] private Projectile projectilePrefab;
+        [SerializeField] private Transform muzzle;
+
+        [Header("Systems")]
+        [SerializeField] private ObjectPooler pooler;
+        [SerializeField] private ObstacleRepurposer repurposer;
+
+        private Coroutine _fireRoutine;
+        private float _currentFireRate;
+
+        private void Awake()
+        {
+            _currentFireRate = fireRate;
+            if (pooler == null)
+            {
+                pooler = FindObjectOfType<ObjectPooler>();
+            }
+        }
+
+        public void ProcessAim(Vector2 aim)
+        {
+            // Convert normalized viewport direction to world aim direction.
+            var worldDir = new Vector3(aim.x, 0f, 1f).normalized;
+            transform.forward = Vector3.Lerp(transform.forward, worldDir, 0.2f);
+        }
+
+        public void BeginFire()
+        {
+            if (_fireRoutine != null)
+            {
+                return;
+            }
+
+            _fireRoutine = StartCoroutine(FireContinuously());
+        }
+
+        public void EndFire()
+        {
+            if (_fireRoutine != null)
+            {
+                StopCoroutine(_fireRoutine);
+                _fireRoutine = null;
+            }
+        }
+
+        public void BoostFireRateTemporary()
+        {
+            StopCoroutine(nameof(BoostRoutine));
+            StartCoroutine(nameof(BoostRoutine));
+        }
+
+        private IEnumerator FireContinuously()
+        {
+            while (true)
+            {
+                FireProjectile();
+                yield return new WaitForSeconds(1f / Mathf.Max(0.01f, _currentFireRate));
+            }
+        }
+
+        private void FireProjectile()
+        {
+            if (projectilePrefab == null || muzzle == null)
+            {
+                Debug.LogWarning("PlayerShooter missing projectile or muzzle reference.");
+                return;
+            }
+
+            var projectile = pooler.Get(projectilePrefab.gameObject, muzzle.position, muzzle.rotation);
+            if (projectile != null && projectile.TryGetComponent(out Projectile projectileComponent))
+            {
+                projectileComponent.Launch(OnProjectileHit);
+            }
+        }
+
+        private void OnProjectileHit(RaycastHit hit)
+        {
+            if (repurposer == null)
+            {
+                return;
+            }
+
+            repurposer.TryRepurpose(hit.collider.gameObject, hit.point, hit.normal);
+        }
+
+        private IEnumerator BoostRoutine()
+        {
+            _currentFireRate = boostedFireRate;
+            yield return new WaitForSeconds(boostedDuration);
+            _currentFireRate = fireRate;
+        }
+    }
+}

--- a/Assets/Scripts/Player/PlayerShootingCoordinator.cs
+++ b/Assets/Scripts/Player/PlayerShootingCoordinator.cs
@@ -1,0 +1,80 @@
+using UnityEngine;
+using AngryDogs.Input;
+
+namespace AngryDogs.Player
+{
+    /// <summary>
+    /// Isolates aiming and firing responsibilities from the high-level player controller.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class PlayerShootingCoordinator : MonoBehaviour
+    {
+        [Header("Dependencies")]
+        [SerializeField] private InputManager inputManager;
+        [SerializeField] private PlayerShooter shooter;
+
+        private void Reset()
+        {
+            shooter = GetComponent<PlayerShooter>();
+            inputManager = FindObjectOfType<InputManager>();
+        }
+
+        private void Awake()
+        {
+            if (shooter == null)
+            {
+                shooter = GetComponent<PlayerShooter>();
+            }
+
+            if (inputManager == null)
+            {
+                inputManager = FindObjectOfType<InputManager>();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Aim += HandleAim;
+                inputManager.FireStarted += HandleFireStarted;
+                inputManager.FireCanceled += HandleFireCanceled;
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (inputManager != null)
+            {
+                inputManager.Aim -= HandleAim;
+                inputManager.FireStarted -= HandleFireStarted;
+                inputManager.FireCanceled -= HandleFireCanceled;
+            }
+        }
+
+        public void HandleGameOver()
+        {
+            shooter?.EndFire();
+        }
+
+        public void HandleCompanionDamage()
+        {
+            shooter?.BoostFireRateTemporary();
+        }
+
+        private void HandleAim(Vector2 aim)
+        {
+            shooter?.ProcessAim(aim);
+        }
+
+        private void HandleFireStarted()
+        {
+            shooter?.BeginFire();
+        }
+
+        private void HandleFireCanceled()
+        {
+            shooter?.EndFire();
+        }
+    }
+}

--- a/Assets/Scripts/SaveSystem/SaveManager.cs
+++ b/Assets/Scripts/SaveSystem/SaveManager.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using UnityEngine;
+using AngryDogs.Data;
+
+namespace AngryDogs.SaveSystem
+{
+    /// <summary>
+    /// Centralised persistence manager responsible for JSON save/load with mobile safe fallbacks.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class SaveManager : MonoBehaviour
+    {
+        private const string SaveFileName = "angry_dogs_save.json";
+        private const string KeyBindingPrefix = "AngryDogs_Key_";
+
+        [Header("Behaviour")]
+        [SerializeField, Tooltip("Automatically load progress during Awake.")]
+        private bool autoLoadOnAwake = true;
+        [SerializeField, Tooltip("Encrypt save payload lightly to deter casual tampering.")]
+        private bool obfuscatePayload = true;
+
+        public event Action<PlayerSaveData> SaveLoaded;
+
+        private PlayerSaveData _cachedSave;
+        private readonly byte[] _xorMask = Encoding.UTF8.GetBytes("RILEY_LOVES_NIBBLE");
+
+        private string SavePath => Path.Combine(Application.persistentDataPath, SaveFileName);
+
+        public PlayerProgressData Progress
+        {
+            get
+            {
+                return Save.Progress;
+            }
+        }
+
+        public PlayerSettingsData Settings => Save.Settings;
+
+        private PlayerSaveData Save
+        {
+            get
+            {
+                _cachedSave ??= PlayerSaveData.CreateDefault();
+                return _cachedSave;
+            }
+        }
+
+        private void Awake()
+        {
+            if (autoLoadOnAwake)
+            {
+                Load();
+            }
+        }
+
+        /// <summary>
+        /// Load persisted data, falling back to defaults when missing or corrupted.
+        /// </summary>
+        public void Load()
+        {
+            _cachedSave = ReadFromDisk();
+            SaveLoaded?.Invoke(Save);
+        }
+
+        /// <summary>
+        /// Persists the current <see cref="PlayerProgressData"/> to storage.
+        /// </summary>
+        public void Save()
+        {
+            if (_cachedSave == null)
+            {
+                Debug.LogWarning("Save() called without cached data. Creating defaults.");
+                _cachedSave = PlayerSaveData.CreateDefault();
+            }
+
+            Save.Progress.Version++;
+            WriteToDisk(Save);
+        }
+
+        /// <summary>
+        /// Store a new high score and optional currency payout before saving.
+        /// </summary>
+        public void SaveRunResults(int score, int currencyReward, IReadOnlyCollection<string> unlockedDuringRun)
+        {
+            var progress = Progress;
+            progress.HighScore = score;
+            progress.Currency = progress.Currency + Mathf.Max(0, currencyReward);
+
+            if (unlockedDuringRun != null)
+            {
+                foreach (var upgradeId in unlockedDuringRun)
+                {
+                    progress.UnlockUpgrade(upgradeId);
+                }
+            }
+
+            Save();
+        }
+
+        /// <summary>
+        /// Unlocks a single upgrade and immediately saves when successful.
+        /// </summary>
+        public bool UnlockUpgrade(string upgradeId)
+        {
+            if (!Progress.UnlockUpgrade(upgradeId))
+            {
+                return false;
+            }
+
+            Save();
+            return true;
+        }
+
+        /// <summary>
+        /// Persist non-binding settings like audio sliders or UI layout tweaks.
+        /// </summary>
+        public void StoreSettings(float musicVolume, float sfxVolume, bool hapticsEnabled, bool leftHandedUi)
+        {
+            var settings = Settings;
+            settings.MusicVolume = musicVolume;
+            settings.SfxVolume = sfxVolume;
+            settings.HapticsEnabled = hapticsEnabled;
+            settings.LeftHandedUi = leftHandedUi;
+            Save();
+        }
+
+        /// <summary>
+        /// Simple binding persistence using PlayerPrefs for cross-platform compatibility.
+        /// </summary>
+        public void StoreKeyBinding(string actionId, KeyCode key)
+        {
+            if (string.IsNullOrEmpty(actionId))
+            {
+                return;
+            }
+
+            Settings.SetBinding(actionId, key);
+            PlayerPrefs.SetInt(KeyBindingPrefix + actionId, (int)key);
+            PlayerPrefs.Save();
+            Save();
+        }
+
+        public KeyCode LoadKeyBinding(string actionId, KeyCode fallback)
+        {
+            if (string.IsNullOrEmpty(actionId))
+            {
+                return fallback;
+            }
+
+            if (PlayerPrefs.HasKey(KeyBindingPrefix + actionId))
+            {
+                return (KeyCode)PlayerPrefs.GetInt(KeyBindingPrefix + actionId, (int)fallback);
+            }
+
+            return Settings.GetBinding(actionId, fallback);
+        }
+
+        public void DeleteSave()
+        {
+            _cachedSave = PlayerSaveData.CreateDefault();
+#if UNITY_WEBGL && !UNITY_EDITOR
+            PlayerPrefs.DeleteKey(SaveFileName);
+            PlayerPrefs.Save();
+#else
+            if (File.Exists(SavePath))
+            {
+                File.Delete(SavePath);
+            }
+#endif
+            foreach (var binding in Settings.Bindings)
+            {
+                if (!string.IsNullOrEmpty(binding.actionId))
+                {
+                    PlayerPrefs.DeleteKey(KeyBindingPrefix + binding.actionId);
+                }
+            }
+            PlayerPrefs.Save();
+            SaveLoaded?.Invoke(Save);
+        }
+
+        private PlayerSaveData ReadFromDisk()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            var payload = PlayerPrefs.GetString(SaveFileName, string.Empty);
+            if (string.IsNullOrEmpty(payload))
+            {
+                return PlayerSaveData.CreateDefault();
+            }
+
+            return Deserialize(payload);
+#else
+            try
+            {
+                if (!File.Exists(SavePath))
+                {
+                    return PlayerSaveData.CreateDefault();
+                }
+
+                using var stream = new FileStream(SavePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var reader = new StreamReader(stream, Encoding.UTF8);
+                var payload = reader.ReadToEnd();
+                return Deserialize(payload);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to load save file at {SavePath}: {ex.Message}");
+                return PlayerSaveData.CreateDefault();
+            }
+#endif
+        }
+
+        private void WriteToDisk(PlayerSaveData data)
+        {
+            var payload = Serialize(data);
+#if UNITY_WEBGL && !UNITY_EDITOR
+            PlayerPrefs.SetString(SaveFileName, payload);
+            PlayerPrefs.Save();
+#else
+            try
+            {
+                var directory = Path.GetDirectoryName(SavePath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                using var stream = new FileStream(SavePath, FileMode.Create, FileAccess.Write, FileShare.None);
+                using var writer = new StreamWriter(stream, Encoding.UTF8);
+                writer.Write(payload);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogError($"Failed to write save file at {SavePath}: {ex.Message}");
+            }
+#endif
+        }
+
+        private string Serialize(PlayerSaveData data)
+        {
+            if (!obfuscatePayload)
+            {
+                return JsonUtility.ToJson(data, prettyPrint: true);
+            }
+
+            var json = JsonUtility.ToJson(data, prettyPrint: false);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            for (var i = 0; i < bytes.Length; i++)
+            {
+                bytes[i] ^= _xorMask[i % _xorMask.Length];
+            }
+
+            return Convert.ToBase64String(bytes);
+        }
+
+        private PlayerSaveData Deserialize(string payload)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(payload))
+                {
+                    return PlayerSaveData.CreateDefault();
+                }
+
+                if (obfuscatePayload)
+                {
+                    var bytes = Convert.FromBase64String(payload);
+                    for (var i = 0; i < bytes.Length; i++)
+                    {
+                        bytes[i] ^= _xorMask[i % _xorMask.Length];
+                    }
+
+                    payload = Encoding.UTF8.GetString(bytes);
+                }
+
+                var data = JsonUtility.FromJson<PlayerSaveData>(payload);
+                return data ?? PlayerSaveData.CreateDefault();
+            }
+            catch (Exception ex)
+            {
+                Debug.LogWarning($"Failed to parse save payload, using defaults. {ex.Message}");
+                return PlayerSaveData.CreateDefault();
+            }
+        }
+
+#if UNITY_EDITOR
+        [ContextMenu("Open Save Location")]
+        private void RevealSaveFolder()
+        {
+            UnityEditor.EditorUtility.RevealInFinder(SavePath);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Systems/HealthComponent.cs
+++ b/Assets/Scripts/Systems/HealthComponent.cs
@@ -1,0 +1,63 @@
+using System;
+using UnityEngine;
+
+namespace AngryDogs.Systems
+{
+    /// <summary>
+    /// Minimal health container with events for damage and death notifications.
+    /// </summary>
+    public sealed class HealthComponent : MonoBehaviour
+    {
+        [SerializeField] private float maxHealth = 100f;
+        [SerializeField] private bool clampNegative = true;
+
+        public float MaxHealth => maxHealth;
+        public float CurrentHealth { get; private set; }
+
+        public event Action<float> Damaged;
+        public event Action<float> Healed;
+        public event Action Died;
+
+        private void Awake()
+        {
+            CurrentHealth = maxHealth;
+        }
+
+        public void ApplyDamage(float amount)
+        {
+            if (amount <= 0f || CurrentHealth <= 0f)
+            {
+                return;
+            }
+
+            CurrentHealth -= amount;
+            if (clampNegative)
+            {
+                CurrentHealth = Mathf.Max(CurrentHealth, 0f);
+            }
+
+            Damaged?.Invoke(CurrentHealth);
+
+            if (CurrentHealth <= 0f)
+            {
+                Died?.Invoke();
+            }
+        }
+
+        public void Restore(float amount)
+        {
+            if (amount <= 0f)
+            {
+                return;
+            }
+
+            CurrentHealth = Mathf.Min(CurrentHealth + amount, maxHealth);
+            Healed?.Invoke(CurrentHealth);
+        }
+
+        public void ResetHealth()
+        {
+            CurrentHealth = maxHealth;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/ObjectPooler.cs
+++ b/Assets/Scripts/Systems/ObjectPooler.cs
@@ -1,0 +1,119 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AngryDogs.Systems
+{
+    /// <summary>
+    /// Generic object pooler for reuse of projectiles, obstacles, hounds, etc.
+    /// Avoids runtime allocations on mobile.
+    /// </summary>
+    public sealed class ObjectPooler : MonoBehaviour
+    {
+        [System.Serializable]
+        private class Pool
+        {
+            public GameObject prefab;
+            public int preload = 8;
+        }
+
+        [SerializeField] private List<Pool> pools = new();
+
+        private readonly Dictionary<GameObject, Queue<GameObject>> _available = new();
+        private readonly Dictionary<GameObject, GameObject> _instanceToPrefab = new();
+
+        private void Awake()
+        {
+            foreach (var pool in pools)
+            {
+                WarmPool(pool);
+            }
+        }
+
+        private void WarmPool(Pool pool)
+        {
+            if (pool.prefab == null)
+            {
+                return;
+            }
+
+            if (!_available.ContainsKey(pool.prefab))
+            {
+                _available[pool.prefab] = new Queue<GameObject>();
+            }
+
+            for (var i = 0; i < pool.preload; i++)
+            {
+                var instance = CreateInstance(pool.prefab);
+                Return(pool.prefab, instance);
+            }
+        }
+
+        public GameObject Get(GameObject prefab, Vector3 position, Quaternion rotation)
+        {
+            if (prefab == null)
+            {
+                Debug.LogWarning("ObjectPooler.Get called with null prefab");
+                return null;
+            }
+
+            if (!_available.TryGetValue(prefab, out var queue) || queue.Count == 0)
+            {
+                var instance = CreateInstance(prefab);
+                return Activate(instance, position, rotation);
+            }
+
+            var pooled = queue.Dequeue();
+            return Activate(pooled, position, rotation);
+        }
+
+        public void Return(GameObject prefab, GameObject instance)
+        {
+            if (prefab == null || instance == null)
+            {
+                return;
+            }
+
+            if (!_available.TryGetValue(prefab, out var queue))
+            {
+                queue = new Queue<GameObject>();
+                _available[prefab] = queue;
+            }
+
+            instance.SetActive(false);
+            instance.transform.SetParent(transform, false);
+            queue.Enqueue(instance);
+        }
+
+        private GameObject CreateInstance(GameObject prefab)
+        {
+            var instance = Instantiate(prefab, transform);
+            _instanceToPrefab[instance] = prefab;
+            return instance;
+        }
+
+        private GameObject Activate(GameObject instance, Vector3 position, Quaternion rotation)
+        {
+            instance.transform.SetParent(null);
+            instance.transform.SetPositionAndRotation(position, rotation);
+            instance.SetActive(true);
+            return instance;
+        }
+
+        public void Return(GameObject instance)
+        {
+            if (instance == null)
+            {
+                return;
+            }
+
+            if (_instanceToPrefab.TryGetValue(instance, out var prefab))
+            {
+                Return(prefab, instance);
+            }
+            else
+            {
+                Destroy(instance);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Systems/ObstacleRepurposer.cs
+++ b/Assets/Scripts/Systems/ObstacleRepurposer.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace AngryDogs.Systems
+{
+    /// <summary>
+    /// Converts destroyed obstacles into defensive traps in-place.
+    /// Designers can hook into OnRepurposed to spawn VFX.
+    /// </summary>
+    public sealed class ObstacleRepurposer : MonoBehaviour
+    {
+        [SerializeField] private LayerMask obstacleMask;
+        [SerializeField] private GameObject trapPrefab;
+        [SerializeField] private ObjectPooler pooler;
+
+        private void Awake()
+        {
+            if (pooler == null)
+            {
+                pooler = FindObjectOfType<ObjectPooler>();
+            }
+        }
+
+        public void TryRepurpose(GameObject hitObject, Vector3 position, Vector3 normal)
+        {
+            if (hitObject == null || ((1 << hitObject.layer) & obstacleMask) == 0)
+            {
+                return;
+            }
+
+            hitObject.SetActive(false);
+
+            if (trapPrefab == null || pooler == null)
+            {
+                return;
+            }
+
+            var trap = pooler.Get(trapPrefab, position, Quaternion.LookRotation(normal));
+            trap.transform.localScale = Vector3.one * 1.25f;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/ObstacleSpawner.cs
+++ b/Assets/Scripts/Systems/ObstacleSpawner.cs
@@ -1,0 +1,100 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AngryDogs.Systems
+{
+    /// <summary>
+    /// Spawns obstacles ahead of the player using weighted lanes and difficulty curves.
+    /// </summary>
+    public sealed class ObstacleSpawner : MonoBehaviour
+    {
+        [System.Serializable]
+        private class SpawnEntry
+        {
+            public GameObject prefab;
+            [Range(0f, 1f)] public float weight = 1f;
+        }
+
+        [SerializeField] private Transform player;
+        [SerializeField] private float spawnDistance = 40f;
+        [SerializeField] private float despawnDistance = 10f;
+        [SerializeField] private int laneCount = 3;
+        [SerializeField] private float laneWidth = 3f;
+        [SerializeField] private List<SpawnEntry> spawnTable = new();
+        [SerializeField] private AnimationCurve spawnRateOverTime = AnimationCurve.Linear(0f, 1.5f, 600f, 0.5f);
+        [SerializeField] private ObjectPooler pooler;
+
+        private readonly List<GameObject> _activeObstacles = new();
+        private float _lastSpawnZ;
+        private float _timeAlive;
+
+        private void Update()
+        {
+            if (player == null || spawnTable.Count == 0)
+            {
+                return;
+            }
+
+            _timeAlive += Time.deltaTime;
+            var targetSpawnInterval = spawnRateOverTime.Evaluate(_timeAlive);
+
+            if (player.position.z - _lastSpawnZ >= targetSpawnInterval)
+            {
+                SpawnObstacle();
+            }
+
+            DespawnBehindPlayer();
+        }
+
+        private void SpawnObstacle()
+        {
+            var prefab = PickWeightedPrefab();
+            if (prefab == null)
+            {
+                return;
+            }
+
+            var laneIndex = Random.Range(0, Mathf.Max(1, laneCount));
+            var centeredIndex = laneIndex - (laneCount - 1) * 0.5f;
+            var spawnPos = player.position + player.forward * spawnDistance + player.right * (centeredIndex * laneWidth);
+            var obstacle = pooler.Get(prefab, spawnPos, Quaternion.identity);
+            _activeObstacles.Add(obstacle);
+            _lastSpawnZ = player.position.z;
+        }
+
+        private void DespawnBehindPlayer()
+        {
+            for (var i = _activeObstacles.Count - 1; i >= 0; i--)
+            {
+                var obstacle = _activeObstacles[i];
+                if (player.position.z - obstacle.transform.position.z > despawnDistance)
+                {
+                    pooler.Return(obstacle);
+                    _activeObstacles.RemoveAt(i);
+                }
+            }
+        }
+
+        private GameObject PickWeightedPrefab()
+        {
+            var totalWeight = 0f;
+            foreach (var entry in spawnTable)
+            {
+                totalWeight += entry.weight;
+            }
+
+            var randomValue = Random.Range(0f, totalWeight);
+            foreach (var entry in spawnTable)
+            {
+                if (randomValue <= entry.weight)
+                {
+                    return entry.prefab;
+                }
+
+                randomValue -= entry.weight;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Assets/Scripts/Systems/Projectile.cs
+++ b/Assets/Scripts/Systems/Projectile.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEngine;
+
+namespace AngryDogs.Systems
+{
+    /// <summary>
+    /// Simple pooled projectile that raycasts forward and notifies callback on impact.
+    /// </summary>
+    [RequireComponent(typeof(Rigidbody))]
+    public sealed class Projectile : MonoBehaviour
+    {
+        [SerializeField] private float speed = 40f;
+        [SerializeField] private float maxLifetime = 5f;
+        [SerializeField] private LayerMask hitMask;
+        [SerializeField] private ObjectPooler pooler;
+
+        private Action<RaycastHit> _onHit;
+        private Rigidbody _rigidbody;
+        private float _lifetime;
+
+        private void Awake()
+        {
+            _rigidbody = GetComponent<Rigidbody>();
+            if (pooler == null)
+            {
+                pooler = FindObjectOfType<ObjectPooler>();
+            }
+        }
+
+        public void Launch(Action<RaycastHit> onHit)
+        {
+            _onHit = onHit;
+            _lifetime = 0f;
+            gameObject.SetActive(true);
+            _rigidbody.velocity = transform.forward * speed;
+        }
+
+        private void Update()
+        {
+            _lifetime += Time.deltaTime;
+            if (_lifetime >= maxLifetime)
+            {
+                ReturnToPool();
+                return;
+            }
+
+            if (Physics.Raycast(transform.position, transform.forward, out var hit, speed * Time.deltaTime, hitMask))
+            {
+                _onHit?.Invoke(hit);
+                ReturnToPool();
+            }
+        }
+
+        private void OnDisable()
+        {
+            _rigidbody.velocity = Vector3.zero;
+            _onHit = null;
+        }
+
+        private void ReturnToPool()
+        {
+            if (pooler != null)
+            {
+                pooler.Return(gameObject);
+            }
+            else
+            {
+                gameObject.SetActive(false);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Tools/AssetImporter.cs
+++ b/Assets/Scripts/Tools/AssetImporter.cs
@@ -1,0 +1,139 @@
+#if UNITY_EDITOR
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+namespace AngryDogs.Tools
+{
+    /// <summary>
+    /// Automates import settings for neon cyberpunk assets to keep draw calls and memory low.
+    /// Drop into an Editor folder or wrap with UNITY_EDITOR as done here.
+    /// </summary>
+    public sealed class AssetImporter : AssetPostprocessor
+    {
+        private static readonly string[] NeonKeywords = { "neon", "holo", "glow" };
+        private static readonly string[] ParticleKeywords = { "fx", "particle", "vfx", "explosion" };
+
+        void OnPreprocessModel()
+        {
+            var importer = (ModelImporter)assetImporter;
+            importer.importMaterials = false; // Materials handled by addressable pipeline.
+            importer.meshCompression = ModelImporterMeshCompression.Medium;
+            importer.optimizeMeshPolygons = true;
+            importer.optimizeMeshVertices = true;
+            importer.isReadable = false;
+            importer.animationCompression = ModelImporterAnimationCompression.Optimal;
+            importer.animationRotationError = 0.5f;
+            importer.animationPositionError = 0.5f;
+        }
+
+        void OnPostprocessModel(GameObject gameObject)
+        {
+            // Auto-add lightweight LODGroups for skyscrapers and chunky props.
+            if (!gameObject.TryGetComponent<LODGroup>(out _))
+            {
+                var renderers = gameObject.GetComponentsInChildren<Renderer>(true);
+                var rendererCount = renderers.Length;
+                if (rendererCount > 4)
+                {
+                    var lodGroup = gameObject.AddComponent<LODGroup>();
+                    lodGroup.fadeMode = LODFadeMode.CrossFade;
+                    lodGroup.animateCrossFading = true;
+                    lodGroup.size = 1f;
+                    lodGroup.SetLODs(new[]
+                    {
+                        new LOD(0.6f, renderers),
+                        new LOD(0.2f, System.Array.Empty<Renderer>())
+                    });
+                }
+            }
+        }
+
+        void OnPreprocessTexture()
+        {
+            var importer = (TextureImporter)assetImporter;
+            importer.textureCompression = TextureImporterCompression.CompressedHQ;
+            importer.mipmapEnabled = true;
+            importer.alphaSource = TextureImporterAlphaSource.FromInput;
+            importer.sRGBTexture = !IsFxTexture(importer.assetPath);
+
+            if (IsFxTexture(importer.assetPath))
+            {
+                importer.alphaIsTransparency = true;
+                importer.anisoLevel = 2;
+            }
+            else
+            {
+                importer.alphaIsTransparency = false;
+                importer.anisoLevel = 1;
+            }
+
+            importer.crunchedCompression = true;
+            importer.compressionQuality = 80;
+
+            importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings
+            {
+                name = "Android",
+                overridden = true,
+                format = TextureImporterFormat.ASTC_6x6,
+                maxTextureSize = 1024,
+                compressionQuality = 80
+            });
+
+            importer.SetPlatformTextureSettings(new TextureImporterPlatformSettings
+            {
+                name = "iPhone",
+                overridden = true,
+                format = TextureImporterFormat.ASTC_6x6,
+                maxTextureSize = 1024,
+                compressionQuality = 80
+            });
+        }
+
+        void OnPreprocessAnimation()
+        {
+            var importer = (ModelImporter)assetImporter;
+            importer.resampleCurves = false;
+        }
+
+        static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, string[] movedAssets, string[] movedFromAssetPaths)
+        {
+            foreach (var path in importedAssets)
+            {
+                if (!path.StartsWith("Assets/Art/"))
+                {
+                    continue;
+                }
+
+                var fileInfo = new FileInfo(path);
+                if (fileInfo.Length > 50 * 1024 * 1024)
+                {
+                    Debug.LogWarning($"{Path.GetFileName(path)} is thicc (>{fileInfo.Length / (1024 * 1024)}MB). Consider reducing texture size or mesh detail.");
+                }
+            }
+        }
+
+        private static bool IsFxTexture(string assetPath)
+        {
+            assetPath = assetPath.ToLowerInvariant();
+            foreach (var keyword in ParticleKeywords)
+            {
+                if (assetPath.Contains(keyword))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var keyword in NeonKeywords)
+            {
+                if (assetPath.Contains(keyword))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using UnityEngine.UI;
+using AngryDogs.Core;
+
+namespace AngryDogs.UI
+{
+    /// <summary>
+    /// Listens to gameplay events and updates HUD widgets.
+    /// </summary>
+    public sealed class HUDController : MonoBehaviour
+    {
+        [SerializeField] private Text scoreText;
+        [SerializeField] private Slider rileyHealthBar;
+        [SerializeField] private Slider nibbleHealthBar;
+        [SerializeField] private Text houndCountText;
+
+        private void OnEnable()
+        {
+            GameEvents.ScoreChanged += HandleScoreChanged;
+            GameEvents.RileyHealthChanged += HandleRileyHealthChanged;
+            GameEvents.NibbleHealthChanged += HandleNibbleHealthChanged;
+            GameEvents.HoundPackCountChanged += HandleHoundCountChanged;
+        }
+
+        private void OnDisable()
+        {
+            GameEvents.ScoreChanged -= HandleScoreChanged;
+            GameEvents.RileyHealthChanged -= HandleRileyHealthChanged;
+            GameEvents.NibbleHealthChanged -= HandleNibbleHealthChanged;
+            GameEvents.HoundPackCountChanged -= HandleHoundCountChanged;
+        }
+
+        private void HandleScoreChanged(int score)
+        {
+            if (scoreText != null)
+            {
+                scoreText.text = score.ToString("N0");
+            }
+        }
+
+        private void HandleRileyHealthChanged(float value)
+        {
+            if (rileyHealthBar != null)
+            {
+                rileyHealthBar.value = value;
+            }
+        }
+
+        private void HandleNibbleHealthChanged(float value)
+        {
+            if (nibbleHealthBar != null)
+            {
+                nibbleHealthBar.value = value;
+            }
+        }
+
+        private void HandleHoundCountChanged(int count)
+        {
+            if (houndCountText != null)
+            {
+                houndCountText.text = $"Hounds: {count}";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/UIManager.cs
+++ b/Assets/Scripts/UI/UIManager.cs
@@ -1,0 +1,250 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.UI;
+using AngryDogs.SaveSystem;
+using AngryDogs.Core;
+using AngryDogs.Data;
+
+namespace AngryDogs.UI
+{
+    /// <summary>
+    /// Centralises navigation between main menu, HUD, pause, and upgrade UI panels with neon flair.
+    /// Uses CanvasGroup fading to keep draw calls friendly for mobile builds.
+    /// </summary>
+    public sealed class UIManager : MonoBehaviour
+    {
+        [System.Serializable]
+        private class ScreenConfig
+        {
+            public string id;
+            public CanvasGroup canvasGroup;
+            [Range(0.05f, 1f)] public float fadeDuration = 0.25f;
+            public AudioClip enterClip;
+            public AudioClip exitClip;
+        }
+
+        [Header("Screens")]
+        [SerializeField] private ScreenConfig mainMenu;
+        [SerializeField] private ScreenConfig hud;
+        [SerializeField] private ScreenConfig pauseMenu;
+        [SerializeField] private ScreenConfig upgradeShop;
+
+        [Header("HUD Widgets")]
+        [SerializeField] private Text scoreLabel;
+        [SerializeField] private Slider rileyHealthBar;
+        [SerializeField] private Slider nibbleHealthBar;
+        [SerializeField] private Text quipLabel;
+
+        [Header("Systems")]
+        [SerializeField] private SaveManager saveManager;
+        [SerializeField] private AudioSource uiAudioSource;
+
+        private Coroutine _fadeRoutine;
+        private ScreenConfig _currentScreen;
+        private int _highScore;
+        private bool _isPaused;
+
+        private void Awake()
+        {
+            if (saveManager != null)
+            {
+                saveManager.SaveLoaded += OnSaveLoaded;
+            }
+
+            GameEvents.GamePaused += HandleGamePaused;
+            GameEvents.GameResumed += HandleGameResumed;
+            GameEvents.GameOver += HandleGameOver;
+
+            ShowScreen(mainMenu);
+        }
+
+        private void OnDestroy()
+        {
+            if (saveManager != null)
+            {
+                saveManager.SaveLoaded -= OnSaveLoaded;
+            }
+
+            GameEvents.GamePaused -= HandleGamePaused;
+            GameEvents.GameResumed -= HandleGameResumed;
+            GameEvents.GameOver -= HandleGameOver;
+        }
+
+        public void UpdateScore(int score)
+        {
+            if (scoreLabel != null)
+            {
+                scoreLabel.text = $"Score: {score}";
+            }
+
+            if (score > _highScore)
+            {
+                _highScore = score;
+                if (quipLabel != null)
+                {
+                    quipLabel.text = "Riley: Beep boop, new high score! Nibble, fetch my trophy.";
+                }
+            }
+        }
+
+        public void UpdateHealth(float rileyNormalized, float nibbleNormalized)
+        {
+            if (rileyHealthBar != null)
+            {
+                rileyHealthBar.value = Mathf.Clamp01(rileyNormalized);
+            }
+
+            if (nibbleHealthBar != null)
+            {
+                nibbleHealthBar.value = Mathf.Clamp01(nibbleNormalized);
+            }
+        }
+
+        public void ShowMainMenu()
+        {
+            ShowScreen(mainMenu);
+        }
+
+        public void ShowHud()
+        {
+            ShowScreen(hud);
+        }
+
+        public void ShowPause()
+        {
+            ShowScreen(pauseMenu);
+        }
+
+        public void ShowUpgradeShop()
+        {
+            ShowScreen(upgradeShop);
+        }
+
+        public void TogglePause()
+        {
+            if (_isPaused)
+            {
+                GameEvents.RaiseGameResumed();
+            }
+            else
+            {
+                GameEvents.RaiseGamePaused();
+            }
+        }
+
+        public void OnResumeRequested()
+        {
+            TogglePause();
+            if (quipLabel != null)
+            {
+                quipLabel.text = "Nibble: *happy bark* (Translation: back to the neon grind!)";
+            }
+        }
+
+        public void OnQuitRequested()
+        {
+            // In editor builds we just log to avoid quitting play mode unexpectedly.
+            Debug.Log("Riley: Rage-quitting? Fine, but the hounds will miss you.");
+#if UNITY_EDITOR
+            UnityEditor.EditorApplication.isPlaying = false;
+#else
+            Application.Quit();
+#endif
+        }
+
+        private void OnSaveLoaded(PlayerSaveData data)
+        {
+            _highScore = data.Progress.HighScore;
+            if (quipLabel != null)
+            {
+                quipLabel.text = $"High Score: {_highScore}. Nibble says that's {Mathf.Max(1, _highScore / 10)} treats.";
+            }
+        }
+
+        private void HandleGamePaused()
+        {
+            _isPaused = true;
+            ShowPause();
+        }
+
+        private void HandleGameResumed()
+        {
+            _isPaused = false;
+            ShowHud();
+        }
+
+        private void HandleGameOver()
+        {
+            _isPaused = false;
+            ShowMainMenu();
+        }
+
+        private void ShowScreen(ScreenConfig target)
+        {
+            if (target == null || target == _currentScreen)
+            {
+                return;
+            }
+
+            if (_fadeRoutine != null)
+            {
+                StopCoroutine(_fadeRoutine);
+            }
+
+            _fadeRoutine = StartCoroutine(FadeRoutine(target));
+        }
+
+        private IEnumerator FadeRoutine(ScreenConfig target)
+        {
+            var previous = _currentScreen;
+            _currentScreen = target;
+
+            if (previous != null && previous.canvasGroup != null)
+            {
+                yield return FadeCanvas(previous.canvasGroup, 0f, previous.fadeDuration);
+                previous.canvasGroup.interactable = false;
+                previous.canvasGroup.blocksRaycasts = false;
+                previous.canvasGroup.gameObject.SetActive(false);
+                PlayClip(previous.exitClip);
+            }
+
+            if (target != null && target.canvasGroup != null)
+            {
+                PlayClip(target.enterClip);
+                target.canvasGroup.gameObject.SetActive(true);
+                target.canvasGroup.interactable = true;
+                target.canvasGroup.blocksRaycasts = true;
+                yield return FadeCanvas(target.canvasGroup, 1f, target.fadeDuration);
+            }
+        }
+
+        private IEnumerator FadeCanvas(CanvasGroup group, float targetAlpha, float duration)
+        {
+            if (group == null)
+            {
+                yield break;
+            }
+
+            var startAlpha = group.alpha;
+            var time = 0f;
+            while (time < duration)
+            {
+                time += Time.unscaledDeltaTime;
+                group.alpha = Mathf.Lerp(startAlpha, targetAlpha, time / duration);
+                yield return null;
+            }
+
+            group.alpha = targetAlpha;
+        }
+
+        private void PlayClip(AudioClip clip)
+        {
+            if (clip == null || uiAudioSource == null)
+            {
+                return;
+            }
+
+            uiAudioSource.PlayOneShot(clip);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/ObstacleManagerTests.cs
+++ b/Assets/Tests/EditMode/ObstacleManagerTests.cs
@@ -1,0 +1,111 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using AngryDogs.Obstacles;
+using AngryDogs.Systems;
+
+namespace AngryDogs.Tests.EditMode
+{
+    public class ObstacleManagerTests
+    {
+        private GameObject _root;
+        private ObstacleManager _manager;
+        private ObjectPooler _pooler;
+        private Transform _player;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _root = new GameObject("ObstacleManagerTests");
+            _manager = _root.AddComponent<ObstacleManager>();
+            _pooler = new GameObject("Pooler").AddComponent<ObjectPooler>();
+            _player = new GameObject("Player").transform;
+
+            // Inject private fields for testing.
+            typeof(ObstacleManager).GetField("pooler", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.SetValue(_manager, _pooler);
+            typeof(ObstacleManager).GetField("player", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.SetValue(_manager, _player);
+
+            _manager.ConfigureObstacles(CreateDefinitions());
+            _manager.SetRandomSeed(42);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(_root);
+            Object.DestroyImmediate(_pooler.gameObject);
+            Object.DestroyImmediate(_player.gameObject);
+        }
+
+        [Test]
+        public void WeightedPicker_PrioritisesHighWeight()
+        {
+            var picker = new WeightedObstaclePicker();
+            picker.Configure(CreateDefinitions());
+
+            var resultLow = picker.Pick(0.05f);
+            var resultHigh = picker.Pick(0.95f);
+
+            Assert.IsNotNull(resultLow);
+            Assert.IsNotNull(resultHigh);
+            Assert.AreNotEqual(resultLow.id, resultHigh.id);
+        }
+
+        [Test]
+        public void NotifyObstacleDestroyed_SpawnsRepurposedTrap()
+        {
+            var definition = new ObstacleManager.ObstacleDefinition
+            {
+                id = "SlimeSlide",
+                obstaclePrefab = new GameObject("ObstaclePrefab"),
+                repurposedPrefab = new GameObject("TrapPrefab"),
+                weight = 1f,
+                despawnDistance = 50f
+            };
+
+            _manager.ConfigureObstacles(new List<ObstacleManager.ObstacleDefinition> { definition });
+
+            // Spawn once to create active obstacle.
+            typeof(ObstacleManager).GetMethod("SpawnObstacle", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.Invoke(_manager, null);
+
+            Assert.AreEqual(1, _manager.ActiveCount);
+
+            // Grab spawned instance from private list for testing.
+            var lookupField = typeof(ObstacleManager).GetField("_activeObstacles", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var activeList = (System.Collections.IList)lookupField?.GetValue(_manager);
+            var activeEntry = activeList?[0];
+            var instanceField = activeEntry?.GetType().GetField("Instance");
+            var obstacleInstance = instanceField?.GetValue(activeEntry) as GameObject;
+            Assert.IsNotNull(obstacleInstance);
+
+            _manager.NotifyObstacleDestroyed(obstacleInstance, Vector3.zero, Vector3.forward);
+
+            Assert.GreaterOrEqual(_manager.ActiveCount, 1, "Repurposed trap should register as active for cleanup");
+        }
+
+        private static List<ObstacleManager.ObstacleDefinition> CreateDefinitions()
+        {
+            return new List<ObstacleManager.ObstacleDefinition>
+            {
+                new ObstacleManager.ObstacleDefinition
+                {
+                    id = "KibbleBot",
+                    obstaclePrefab = new GameObject("KibbleBot"),
+                    weight = 3f,
+                    despawnDistance = 40f
+                },
+                new ObstacleManager.ObstacleDefinition
+                {
+                    id = "HoloPaw",
+                    obstaclePrefab = new GameObject("HoloPaw"),
+                    repurposedPrefab = new GameObject("HoloTrap"),
+                    weight = 1f,
+                    despawnDistance = 40f
+                }
+            };
+        }
+    }
+}

--- a/Docs/AngryDogsArchitecture.md
+++ b/Docs/AngryDogsArchitecture.md
@@ -1,0 +1,157 @@
+# Angry Dogs – Production Architecture & Pipelines
+
+This document outlines a production-ready refactor plan for the **Angry Dogs** prototype. It covers architecture guidelines, feature-specific implementation notes, asset and build pipelines, as well as performance considerations for mobile and PC.
+
+---
+
+## 1. Architectural Overview
+
+### 1.1 Layered, Component-Oriented Approach
+- **Presentation Layer** – `MonoBehaviour` components responsible for visuals, Unity callbacks, and lightweight orchestration (e.g., `PlayerController`, `HUDController`).
+- **Domain Layer** – Plain C# classes encapsulating gameplay logic (e.g., `HoundBehaviour`, weapon logic, upgrade rules). These classes are unit-testable.
+- **Systems Layer** – Services accessed via dependency injection or a simple service locator (`GameBootstrapper`). Examples: input abstraction, save system, object pooling, spawn manager.
+- **Data Layer** – `ScriptableObject` assets for tunable data (upgrades, enemy stats, spawn tables) + serializable POCOs for runtime state (`PlayerProgressData`).
+
+> **Why not ECS?** The hybrid runner/shooter loop relies heavily on Unity components (animations, VFX, NavMesh). A carefully composed component-based design keeps the project approachable for designers and accommodates Unity tooling (Timeline, Animator). ECS can be selectively introduced later for extremely hot paths (e.g., crowd simulation) if profiling proves it necessary.
+
+### 1.2 Key Patterns
+- **Command Pattern for Input** – Map touch/mouse/keyboard into high-level commands consumed by controllers.
+- **State Machines** – Reusable `GameStateMachine` handles menu, gameplay, pause, and game-over states. Enemy state machines remain lightweight to minimize per-frame allocations.
+- **Event Aggregation** – `GameEvents` centralizes gameplay events (score, health, hound defeated) to decouple systems like UI and audio.
+- **Object Pooling** – All projectiles, obstacles, and hounds should be pooled to keep allocation-free gameplay on mobile.
+
+---
+
+## 2. Step-by-Step Refactor Plan
+
+1. **Bootstrap Services**
+   - Implement `GameBootstrapper` prefab in the root of the main scene. It registers the input handler, object pooler, save system, and audio facade.
+   - Expose initialization order and ensure components survive scene reloads.
+
+2. **Refactor Player Flow**
+   - Split responsibilities across dedicated components:
+     - `PlayerController` (lightweight wiring between coordinators).
+     - `PlayerMovementCoordinator` (subscribes to `InputManager` and feeds `PlayerMovementController`).
+     - `PlayerShootingCoordinator` (aim + fire handling, reacts to Nibble buffs).
+     - `NibbleInteractionCoordinator` (ability triggers and bark-worthy callbacks).
+     - `PlayerHealthResponder` (health events, cooldown throttling, `GameEvents`).
+     - `PlayerMovementController` & `PlayerShooter` keep the heavy lifting logic.
+   - Route input exclusively through the shared `InputManager` to allow rebinding and platform-specific smoothing.
+
+3. **Enhance Input Handling**
+   - `InputManager` wraps the Unity Input System when present and falls back to `Input` APIs on mobile/legacy builds.
+   - Provide swipe-driven dodge controls, smooth aim interpolation, and PlayerPrefs-backed key rebinding.
+
+4. **Enemy & Obstacle Systems**
+   - Create reusable `HoundAIController` with deterministic update order, grouping, and distance-based LOD.
+   - Create `ObstacleSpawner` + `ObstacleRepurposer`. Keep the physics colliders simple (box/capsule) and pre-bake navmesh obstacles.
+
+5. **UI & Game States**
+   - Connect `HUDController`, `PauseMenuController`, `MainMenuController` to `GameStateMachine`.
+   - Use `ScriptableObject` view models for upgrades to easily populate shop UI.
+
+6. **Persistence**
+   - Implement `SaveManager` storing JSON in `Application.persistentDataPath`. Obfuscate payload for tamper resistance and persist key bindings.
+
+7. **Testing**
+   - Extract logic from `MonoBehaviour` classes into plain classes and write `EditMode` tests for scoring, enemy waves, and upgrade calculations.
+   - Use Unity Test Runner with `NUnit`.
+
+---
+
+## 3. Asset & Scene Organization
+
+### 3.1 Folder Structure (`Assets/`)
+```
+Art/
+  Characters/
+  Environment/
+  FX/
+Audio/
+Prefabs/
+  Player/
+  Enemies/
+  Obstacles/
+  UI/
+Scenes/
+  MainMenu.unity
+  Gameplay.unity
+Scripts/
+  Core/
+  Input/
+  Player/
+  Enemies/
+  Systems/
+  Data/
+  UI/
+ScriptableObjects/
+  Upgrades/
+  EnemyWaves/
+  DifficultyCurves/
+Addressables/
+```
+
+### 3.2 Asset Pipeline Tips
+- **Neon Cyberpunk Models** – Keep emissive textures in a separate channel. Use HDR emissive colours with bloom in URP. Pack secondary detail maps into channel masks to reduce texture count.
+- **Particle Effects** – Bake loops into SpriteSheets or VFX Graph outputs; use GPU instancing for repeated effects (muzzle flashes, neon sparks).
+- **Animation Imports** – Disable unnecessary curves (scale, unused bones) to reduce data size. Use retargetable humanoid rigs for hounds if they share animations.
+- **Addressables** – Group large environment sets and high-resolution textures under Addressables for progressive loading on mobile.
+
+### 3.3 Scene Organization
+- Keep a single root `Environment` object with subgroups for static meshes (`StaticGeometry`), dynamic obstacles (`DynamicGeometry`), and VFX (`CityFX`).
+- Use `DontDestroyOnLoad` only for persistent managers (`GameBootstrapper`).
+- Prefabs should be modular: `PlayerRoot` prefab contains child prefabs for movement, shooter, VFX, audio.
+
+---
+
+## 4. Performance Guidelines
+
+### 4.1 Mobile Targets
+- Limit hound skinned mesh renderers to ~15k triangles each. Provide lower LOD (static mesh impostors) for distant packs.
+- Cap simultaneous particle systems; pre-warm loops and reuse them via pooling.
+- Enable URP forward renderer with **dynamic resolution** (80–100%) on mobile.
+- Use `LateUpdate` only when necessary; prefer `FixedUpdate` for physics and `Update` for AI.
+
+### 4.2 Enemy Optimization
+- Batch AI updates: process hounds in groups every other frame using a modulo index to reduce CPU spikes.
+- Use `Physics.OverlapSphereNonAlloc` for detection cones to avoid GC.
+- Disable `NavMeshAgent` when hounds perform melee to reduce path recalculations.
+
+### 4.3 Dynamic Obstacles & VFX
+- Bake occlusion culling volumes for neon skyscrapers.
+- Combine static neon signage meshes by material to reduce draw calls.
+- Use shader LODs to swap between full neon glow and cheap fresnel on low-end devices.
+
+---
+
+## 5. Build & Deployment
+
+1. **Platform Profiles**
+   - Maintain platform-specific quality presets (PC Ultra, PC Low, Mobile High, Mobile Low). Toggle bloom, shadow cascades, and dynamic resolution accordingly.
+
+2. **Automated Builds**
+   - Use Unity Cloud Build or a CI pipeline invoking `Unity -batchmode -executeMethod BuildPipeline` to output iOS/Android/PC builds.
+   - Keep secrets (keystores, provisioning profiles) out of source control.
+
+3. **Resolution & UI Scaling**
+   - Canvas set to `Scale With Screen Size` and anchored for safe areas (iOS notch).
+   - Provide control remapping UI for PC.
+
+---
+
+## 6. Future Enhancements
+- Integrate analytics events (anonymized) to track upgrade usage and hound defeat rates.
+- Implement daily challenges via server-configured JSON to avoid app updates.
+- Investigate DOTS for large-scale hound stampedes if target count exceeds 60 concurrently.
+
+---
+
+## 7. Quick Checklist
+- [ ] Replace prototype `PlayerController` with orchestrator + modular components.
+- [ ] Migrate input to `InputManager` with smoothing.
+- [ ] Pool projectiles, obstacles, hounds.
+- [ ] Implement `SaveManager` with versioned JSON.
+- [ ] Configure Addressables for heavy neon assets.
+- [ ] Profile on mobile hardware (60 FPS, 20 hounds minimum).
+- [ ] Validate UI across aspect ratios.
+

--- a/Docs/AssetPipeline.md
+++ b/Docs/AssetPipeline.md
@@ -1,0 +1,45 @@
+# Angry Dogs Asset Pipeline Cheat Sheet
+
+To keep Riley's neon playground performant on mid-range mobile devices while still looking like a synthwave fever dream, import assets with the following workflow:
+
+## 1. Source Control & Naming
+1. Place raw deliveries from artists in `Assets/Art/_Source/` and keep them out of builds.
+2. Convert and re-export optimized versions into platform-ready folders (e.g., `Assets/Art/Environment/`, `Assets/Art/Characters/`).
+3. Use consistent prefixes per asset type to keep the Project window sorted:
+   - `ENV_` for static environment meshes (skyscrapers, billboards).
+   - `OBS_` for interactive obstacles (slobber cannons, hackable drones).
+   - `FX_` for VFX Graph or particle prefabs (neon explosions, hound drool).
+   - `DOG_` for hound models/animations (e.g., `DOG_CyberChihuahua_Idle`).
+
+## 2. Model Import Settings
+1. Enable **Read/Write** only when deformations are required (e.g., skinned hounds). Disable it for static city meshes to halve memory.
+2. Set **Mesh Compression** to `Medium` for environment pieces; keep characters at `Low` to preserve snouts and rocket tails.
+3. Generate lightmap UVs during import for modular buildings so that baked GI runs cleanly on PC, but keep them disabled on tiny props to save time.
+4. If an artist sends 4K neon textures, downscale to 1K for mobile variants using Texture Importer presets. Use secondary detail maps for PC if needed.
+
+## 3. Animation & Rigging
+1. Store master FBX files with all takes in `Assets/Art/_Source/Animations/`.
+2. Create dedicated Animator Controllers per hound archetype in `Assets/Art/Characters/Hounds/Animators/`.
+3. Use retargeting via Humanoid rigs when possible so new silly animations (e.g., "butt rocket charge") drop in without recoding.
+4. Bake root motion only when hounds must sync with cinematic moments; otherwise, drive forward motion through code for pooling compatibility.
+
+## 4. VFX & Materials
+1. Prefer GPU-friendly shader graphs with single texture atlases. Group neon signage and holograms into atlases to minimise draw calls.
+2. Build particle systems with **Soft Particles** disabled on mobile and capped at 15 particles per system. Keep CPU-based collision off; use trigger volumes instead.
+3. For stylised neon trails, use the VFX Graph on PC/console and a baked mesh trail on mobile fallback. Gate the choice with graphics tiers.
+
+## 5. Audio & Voice Lines
+1. Store quips and barks as `.wav` in `Assets/Art/Audio/_Source/`, then compress to `.ogg` in `Assets/Art/Audio/Processed/` using Unity's importer presets.
+2. Batch import Riley's voice lines and name them `VO_Riley_<Context>` so designers can hook them into timelines quickly.
+
+## 6. Prefab Variants
+1. Create master prefabs in `Assets/Art/Prefabs/Master/` and create lightweight mobile variants in `Assets/Art/Prefabs/Mobile/` with simplified materials and LODs.
+2. Use nested prefabs for obstacles: base mesh + effect child + collider. Designers can then swap FX variants without touching colliders.
+
+## 7. Performance & QA Checklist
+- Run the **Mesh Simplifier** or Unity's LOD Generator for any mesh visible for less than 3 seconds.
+- Audit draw calls with the Frame Debugger. Aim for < 120 draw calls on mobile scenes.
+- Use the **Profiler** and **Memory Profiler** every milestone; pooled hounds should not allocate when respawning.
+- Document texture budgets per biome inside `Docs/Art/` so contractors know the neon limit.
+
+Following this pipeline keeps Angry Dogs visually loud while quietly efficient.

--- a/README.md
+++ b/README.md
@@ -61,3 +61,16 @@ This is a prototype for the "Angry Dogs" game concept. The code is structured to
 ## License
 
 This prototype is for demonstration purposes. All game concepts and designs are original creative works.
+## Unity Refactor Blueprint (Angry Dogs)
+
+Production-ready C# scaffolding for the Unity prototype lives under `Assets/Scripts/`. Key highlights:
+
+- `Core/` contains bootstrapper, events, and state machine helpers.
+- `Input/InputManager` unifies legacy and new Input System controls with smoothing and key rebinding.
+- `Player/` splits Riley's behaviour into movement, shooting, and Nibble support for SOLID compliance.
+- `Enemies/HoundAIController` implements pooled-friendly hound logic with fear debuffs and attack throttling.
+- `Systems/` hosts reusable services (object pooling, save/load, obstacle spawning and repurposing).
+- `Data/` adds serializable save data and ScriptableObject upgrade definitions.
+- `UI/HUDController` reacts to gameplay events for HUD updates.
+
+See `Docs/AngryDogsArchitecture.md` for a detailed migration plan covering asset workflow, performance, and build considerations.


### PR DESCRIPTION
## Summary
- add PlayerSaveData/PlayerSettingsData and expand SaveManager to persist settings, keybindings, and cross-platform payloads
- create a neon-flavored UIManager plus GameStateMachine updates and HoundAI scheduling tweaks to keep menus responsive and 20+ hounds cheaper
- build an obstacle repurposing system with weighted spawning, automated asset import settings, and edit-mode tests covering trap conversion

## Testing
- not run (Unity-specific components)


------
https://chatgpt.com/codex/tasks/task_e_68d68f00e464832696e390c07624c3fc